### PR TITLE
English language text improvements

### DIFF
--- a/dat/battles/tutorial_battle_dialogs.lua
+++ b/dat/battles/tutorial_battle_dialogs.lua
@@ -38,7 +38,7 @@ function Initialize(battle_instance)
 	-- of battle, before any action can be taken. The player is presented with several options that they can read to get more information on
 	-- the battle system. One of the options that the player may select from will finish the dialogue, allow the battle to resume.
 	main_dialogue = hoa_battle.BattleDialogue(1);
-		text = hoa_system.Translate("Woah, I wouldn't have expected enemies so close from the village. Bronann, is there anything you need to ask about battles?");
+		text = hoa_system.Translate("Woah, I wouldn't have expected enemies so close to the village. Bronann, is there anything that you need to ask about battles?");
 		main_dialogue:AddLine(text, 1002);
 		text = hoa_system.Translate("...");
 		main_dialogue:AddLine(text, 1000);
@@ -48,18 +48,18 @@ function Initialize(battle_instance)
 		main_dialogue:AddOption(text, 8);
 		text = hoa_system.Translate("Ask about status effects.");
 		main_dialogue:AddOption(text, 15);
-		text = hoa_system.Translate("Ask nothing, I know how to fight.");
+		text = hoa_system.Translate("Ask nothing. I know how to fight.");
 		main_dialogue:AddOption(text, 21);
 		-- [Line 2] After selecting option: Ask about battle basics.
 		text = hoa_system.Translate("Er, I could use a refresher on the fundamentals of combat.");
 		main_dialogue:AddLine(text, 1000);
-		text = hoa_system.Translate("Every actor on the battle scene has a hit point (HP) and skill point (SP) gauge. Each character's HP and SP are displayed at the bottom of the screen. As enemies take damage in battle, their appearance will reflect that damage.");
+		text = hoa_system.Translate("Every actor on the battle screen has a hit point (HP) and skill point (SP) gauge. Each character's HP and SP are displayed at the bottom of the screen. As enemies take damage in battle, their appearance will reflect that damage.");
 		main_dialogue:AddLine(text, 1002);
-		text = hoa_system.Translate("When an actor's HP reaches zero they become incapacitated. Victory in battle is obtained by reducing the HP of all enemies to zero.");
+		text = hoa_system.Translate("When an actor's HP reaches zero, they become incapacitated. Victory in battle is obtained by reducing the HP of all enemies to zero.");
 		main_dialogue:AddLine(text, 1002);
-		text = hoa_system.Translate("Every action taken in battle requires SP before it is able to be used. The most basic of actions do not require SP to be able to be used. Using an item consumes no SP.");
+		text = hoa_system.Translate("Every action taken in battle requires some amount of SP before it is able to be used. Most basic actions consume no SP. Using an item also consumes no SP.");
 		main_dialogue:AddLine(text, 1002);
-		text = hoa_system.Translate("The stamina gauge on the right side of the screen determines when an actor may take an action. Once an actor's icon reaches the green command bar, they will begin preparing to execute their selected action. When they reach the top of the gauge, they will execute their action.");
+		text = hoa_system.Translate("The stamina gauge on the right side of the screen determines when an actor may take an action. Once an actor's icon reaches the green command bar, they will begin preparing to execute their selected action. When they reach the top of the gauge, they will execute that action.");
 		main_dialogue:AddLine(text, 1002);
 		text = hoa_system.Translate("The lower right corner of the screen displays each character's selected action and target. When a command is being issued for a character, this area of the screen is replaced with the command menu.");
 		main_dialogue:AddLine(text, 1002, 22);
@@ -70,7 +70,7 @@ function Initialize(battle_instance)
 		main_dialogue:AddLine(text, 1002);
 		text = hoa_system.Translate("Battle actions requires a certain amount of time to prepare to use as well as time to recover from after using. These periods are known as the warm up time and cool down periods. In general, the more powerful the skill the longer these periods will be.");
 		main_dialogue:AddLine(text, 1002);
-		text = hoa_system.Translate("At the bottom of the screen a directional button is shown for each character that you may select a command for. You can set or change the action and/or target issued to a character whenever these buttons are visible.");
+		text = hoa_system.Translate("At the bottom of the screen, a directional button is shown for each character that you may select a command for. You can set or change the action and/or target issued to a character whenever these buttons are visible.");
 		main_dialogue:AddLine(text, 1002);
 		text = hoa_system.Translate("Once the character's icon reaches the green command bar on the stamina gauge, they will begin preparing to execute any action they have set. If a character does not have a command set when their icon reaches the green command bar, the battle will stop until a command is issued for that character.");
 		main_dialogue:AddLine(text, 1002);
@@ -81,7 +81,7 @@ function Initialize(battle_instance)
 		-- [Line 15] After selecting option: Ask about about status effects.
 		text = hoa_system.Translate("What do I need to know about status effects?");
 		main_dialogue:AddLine(text, 1000);
-		text = hoa_system.Translate("Status effects cause temporary changes in the state of the afflicted actor. These changes may be either beneficial or harmful to the their target. Positive status effects are indicated by an upward green arrow on the status icon, where as a negative status effect displays a downward red arrow on its icon.");
+		text = hoa_system.Translate("Status effects cause temporary changes in the state of the afflicted actor. These changes may be either beneficial or harmful to the their target. Positive status effects are indicated by an upward green arrow on the status icon, whereas a negative status effect displays a downward red arrow on its icon.");
 		main_dialogue:AddLine(text, 1002);
 		text = hoa_system.Translate("There are a total of four intensity levels for each status effect. As an example, if you target an actor that is already inflicted with a negative reduction in strength with a skill that reduces strength, the intensity of the status will be increased.");
 		main_dialogue:AddLine(text, 1002);

--- a/dat/maps/layna_forest/layna_forest_north_east.lua
+++ b/dat/maps/layna_forest/layna_forest_north_east.lua
@@ -825,7 +825,7 @@ function _CreateEvents()
     EventManager:RegisterEvent(event);
 
     dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("What's that?!...");
+	text = hoa_system.Translate("What's that?!");
 	dialogue:AddLineEmote(text, hero, "exclamation");
 	DialogueManager:AddDialogue(dialogue);
     event = hoa_map.DialogueEvent("boss fight pre-dialogue", dialogue);
@@ -854,9 +854,9 @@ function _CreateEvents()
     EventManager:RegisterEvent(event);
 
     dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Woah, it was quite nasty fight. Why on earth was an arctic north white wolf lurking in the forest?");
+	text = hoa_system.Translate("Woah, that was quite a nasty fight. Why on earth was an arctic north white wolf lurking in the forest?");
 	dialogue:AddLineEmote(text, hero, "sweat drop");
-	text = hoa_system.Translate("He just flew away. I'm almost sure we'll meet it again. We'd better be well prepared, then...");
+	text = hoa_system.Translate("He just ran away. I'm almost sure we'll meet it again. We'd better be well prepared, then.");
 	dialogue:AddLineEmote(text, hero, "thinking dots");
 	DialogueManager:AddDialogue(dialogue);
     event = hoa_map.DialogueEvent("boss fight post-dialogue", dialogue);

--- a/dat/maps/layna_forest/layna_forest_north_west.lua
+++ b/dat/maps/layna_forest/layna_forest_north_west.lua
@@ -1284,7 +1284,7 @@ function _CreateEvents()
 	dialogue = hoa_map.SpriteDialogue();
 	text = hoa_system.Translate("Orlinn, stop it RIGHT NOW!!");
 	dialogue:AddLineEmote(text, kalya_sprite, "exclamation");
-	text = hoa_system.Translate("I can't Sis'. I can feel it... calling me...");
+	text = hoa_system.Translate("I can't sis. I can feel it... calling me...");
 	dialogue:AddLine(text, orlinn);
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Kalya tries to discuss with Orlinn", dialogue);

--- a/dat/maps/layna_forest/layna_forest_south_west.lua
+++ b/dat/maps/layna_forest/layna_forest_south_west.lua
@@ -911,7 +911,7 @@ function _CreateEvents()
     EventManager:RegisterEvent(move_next_to_hero_event);
 
     dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Woa, wait!");
+	text = hoa_system.Translate("Woah, wait!");
 	dialogue:AddLineEventEmote(text, kalya_sprite, "Bronann looks at Kalya", "Kalya looks at Bronann", "exclamation");
 	text = hoa_system.Translate("Look at that grass. The snakes like it very much. Beware of them, their venom can send you to sleep.");
 	dialogue:AddLine(text, kalya_sprite);

--- a/dat/maps/layna_forest_entrance.lua
+++ b/dat/maps/layna_forest_entrance.lua
@@ -594,7 +594,7 @@ function _CreateEvents()
     EventManager:RegisterEvent(move_next_to_hero_event);
 
     dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("What's that?!...");
+	text = hoa_system.Translate("What's that?!");
 	dialogue:AddLineEmote(text, kalya_sprite, "exclamation");
 	DialogueManager:AddDialogue(dialogue);
     event = hoa_map.DialogueEvent("Kalya is surprised before running to the save point", dialogue);
@@ -609,17 +609,17 @@ function _CreateEvents()
     EventManager:RegisterEvent(event);
 
     dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Can you also see this strange circle surrounded by light??");
+	text = hoa_system.Translate("Can you also see this strange circle surrounded by light?");
 	dialogue:AddLineEventEmote(text, kalya_sprite, "Kalya looks at Bronann", "", "exclamation");
-    text = hoa_system.Translate("When I'm standing near you, I can!");
+    text = hoa_system.Translate("When I'm standing near you, I can.");
     dialogue:AddLineEventEmote(text, hero, "Bronann looks at Kalya", "", "thinking dots");
-    text = hoa_system.Translate("Strange ... it sounds familiar to me. Like ... A safe place to be.");
+    text = hoa_system.Translate("Strange... it sounds familiar to me. Like... A safe place to be.");
     dialogue:AddLineEvent(text, kalya_sprite, "Kalya looks at the save point", "");
     text = hoa_system.Translate("I feel like I can go in there...");
     dialogue:AddLine(text, kalya_sprite);
     text = hoa_system.Translate("Be careful, Kalya!");
     dialogue:AddLineEmote(text, hero, "exclamation");
-    text = hoa_system.Translate("It is like... calling me.");
+    text = hoa_system.Translate("It is like... it's calling me.");
     dialogue:AddLine(text, kalya_sprite);
 	DialogueManager:AddDialogue(dialogue);
     event = hoa_map.DialogueEvent("Kalya starts to talk about the save point", dialogue);

--- a/dat/maps/layna_village/layna_village_bronanns_home.lua
+++ b/dat/maps/layna_village/layna_village_bronanns_home.lua
@@ -309,9 +309,9 @@ function _CreateNPCs()
 	end
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Hey Son! Slept well? Err, where is that oil lamp already?");
+	text = hoa_system.Translate("Hey son! Slept well? Err, where did I leave that oil lamp?");
 	dialogue:AddLine(text, bronanns_dad);
-	text = hoa_system.Translate("Hi Dad! Er, I don't know, sorry.");
+	text = hoa_system.Translate("Hi Dad! Er, I don't know. Sorry.");
 	dialogue:AddLineEmote(text, bronann, "thinking dots");
 	text = hoa_system.Translate("Nah, no problem, I'll find it.");
 	dialogue:AddLine(text, bronanns_dad);
@@ -389,9 +389,9 @@ function _CreateNPCs()
 	dialogue = hoa_map.SpriteDialogue();
 	text = hoa_system.Translate("Now that you're *finally* up, could you go and buy some barley meal for us three?");
 	dialogue:AddLine(text, bronanns_mother);
-	text = hoa_system.Translate("Barley meal, err, again?");
+	text = hoa_system.Translate("Barley meal again?");
 	dialogue:AddLineEmote(text, bronann, "sweat drop");
-	text = hoa_system.Translate("Hmm, hmm, just go boy. You'll be free after that, ok?");
+	text = hoa_system.Translate("Hmph, just go, boy. You'll be free after that, ok?");
 	dialogue:AddLine(text, bronanns_mother);
 	text = hoa_system.Translate("Ok, right!");
 	dialogue:AddLine(text, bronann);
@@ -518,7 +518,7 @@ function _CreateEvents()
     dialogue = hoa_map.SpriteDialogue();
     text = hoa_system.Translate("Thanks for helping me out with the dishes.");
     dialogue:AddLine(text, bronanns_mother);
-    text = hoa_system.Translate("Hmm, say Mom, why is the village entrance blocked?");
+    text = hoa_system.Translate("Hmm, say, mom? Why is the village entrance blocked?");
     dialogue:AddLineEmote(text, bronann, "thinking dots");
     text = hoa_system.Translate("...");
     dialogue:AddLineEmote(text, bronanns_mother, "sweat drop");
@@ -544,13 +544,13 @@ function _CreateEvents()
     EventManager:RegisterEvent(event);
 
     dialogue = hoa_map.SpriteDialogue();
-    text = hoa_system.Translate("Bronann, I'd like you not to go outside today.");
+    text = hoa_system.Translate("Bronann, I'd like you to not go outside today.");
     dialogue:AddLine(text, bronanns_dad);
     text = hoa_system.Translate("Huh?! Why? You told me I could go into the forest and...");
     dialogue:AddLineEmote(text, bronann, "exclamation");
-    text = hoa_system.Translate("Sorry, Son. It's maybe a bit early, but I'd like you to be careful.");
+    text = hoa_system.Translate("Sorry, son. It's maybe a bit early, but I'd like you to be careful.");
     dialogue:AddLine(text, bronanns_dad);
-    text = hoa_system.Translate("Hey, wait! Every elders in the village are on nerves. There is something going on here! Won't you tell me?");
+    text = hoa_system.Translate("Hey, wait! All of the elders in the village are on their nerves. There is something going on here! Why won't you tell me?");
     dialogue:AddLineEventEmote(text, bronann, "", "Quest2: Bronann looks at both parents", "interrogation");
     text = hoa_system.Translate("None of you?");
     dialogue:AddLine(text, bronann);
@@ -570,11 +570,11 @@ function _CreateEvents()
     dialogue = hoa_map.SpriteDialogue();
     text = hoa_system.Translate("Bronann, this time I want you to listen to your father very carefully. Please, my dear.");
     dialogue:AddLine(text, bronanns_mother);
-    text = hoa_system.Translate("But Mom!");
+    text = hoa_system.Translate("But mom!");
     dialogue:AddLine(text, bronann);
     text = hoa_system.Translate("Bronann, please.");
     dialogue:AddLine(text, bronanns_dad);
-    text = hoa_system.Translate("(Grumble) ... Crap!");
+    text = hoa_system.Translate("(grumble)... Crap!");
     dialogue:AddLineEventEmote(text, bronann, "Quest2: Bronann is frustrated", "", "exclamation");
     DialogueManager:AddDialogue(dialogue);
     event = hoa_map.DialogueEvent("Quest2: Bronann is told not to leave town - part 3", dialogue);
@@ -602,7 +602,7 @@ function _CreateEvents()
     dialogue = hoa_map.SpriteDialogue();
     text = hoa_system.Translate("Maybe we should tell him...");
     dialogue:AddLine(text, bronanns_mother);
-    text = hoa_system.Translate("It's too early, Darling. We might be wrong.");
+    text = hoa_system.Translate("It's too early, darling. We might be wrong.");
     dialogue:AddLineEmote(text, bronanns_dad, "thinking dots");
     text = hoa_system.Translate("I really hope we are...");
     dialogue:AddLine(text, bronanns_dad);
@@ -692,7 +692,7 @@ function _UpdateMotherDialogue()
         -- Got some barley meal, Mom!
 		-- Begining dialogue
 		local dialogue = hoa_map.SpriteDialogue();
-		local text = hoa_system.Translate("Sigh... got it, Mom!");
+		local text = hoa_system.Translate("Sigh... got it, mom!");
 		dialogue:AddLine(text, bronann);
 		text = hoa_system.Translate("Perfect timing, let's have dinner.");
 		dialogue:AddLineEvent(text, bronanns_mother, "", "Quest1: end and transition to after-dinner");
@@ -708,11 +708,11 @@ function _UpdateMotherDialogue()
 	elseif (GlobalManager:DoesEventExist("bronanns_home", "quest1_mother_start_dialogue_done") == false) then
 		-- Begining dialogue
 		local dialogue = hoa_map.SpriteDialogue();
-		local text = hoa_system.Translate("Hi Son, did you have a nightmare this night also?");
+		local text = hoa_system.Translate("Hi son, did you also have a nightmare last night?");
 		dialogue:AddLine(text, bronanns_mother);
-		text = hoa_system.Translate("Hi Mom, huh, how do you know...");
+		text = hoa_system.Translate("Hi mom. Huh, how do you know...");
 		dialogue:AddLineEmote(text, bronann, "interrogation");
-		text = hoa_system.Translate("Eh eh, have you already forgotten I'm your mother?");
+		text = hoa_system.Translate("Eh eh? Have you already forgotten I'm your mother?");
 		dialogue:AddLine(text, bronanns_mother);
 		DialogueManager:AddDialogue(dialogue);
 		bronanns_mother:AddDialogueReference(dialogue);

--- a/dat/maps/layna_village/layna_village_center.lua
+++ b/dat/maps/layna_village/layna_village_center.lua
@@ -451,11 +451,11 @@ function _CreateNPCs()
 
         elseif (GlobalManager:DoesEventExist("story", "Quest2_wants_to_buy_sword_dialogue") == false) then
             dialogue = hoa_map.SpriteDialogue();
-            text = hoa_system.Translate("Bronann! Sorry, you can't access the forest without permission. You don't even have a sword..");
+            text = hoa_system.Translate("Bronann! Sorry, you can't access the forest without permission. You don't even have a sword...");
             dialogue:AddLineEmote(text, olivia, "exclamation");
             text = hoa_system.Translate("Aww... Ok.");
             dialogue:AddLineEventEmote(text, bronann, "Bronann looks at Olivia", "", "sweat drop");
-            text = hoa_system.Translate("(Hmm, I should maybe get a sword, then.)");
+            text = hoa_system.Translate("(Hmm, maybe I should get a sword then.)");
             dialogue:AddLineEventEmote(text, bronann, "Bronann looks south", "", "thinking dots");
             DialogueManager:AddDialogue(dialogue);
             olivia:AddDialogueReference(dialogue);
@@ -678,9 +678,9 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Why everybody doesn't want to tell me what's going on!!");
+	text = hoa_system.Translate("Why doesn't anyone want to tell me what's going on!!");
 	dialogue:AddLineEmote(text, bronann, "exclamation");
-	text = hoa_system.Translate("Still, I have go there, and figure out what they're trying to hide from me.");
+	text = hoa_system.Translate("Still, I have go there and figure out what they're trying to hide from me.");
 	dialogue:AddLineEmote(text, bronann, "thinking dots");
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Quest2: Bronann wants to see Flora for equipment", dialogue);
@@ -745,7 +745,7 @@ function _CreateEvents()
 	dialogue:AddLine(text, carson);
 	text = hoa_system.Translate("... Hmmm...");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("Bronann, there is something I have to tell you. We've been afraid of that moment, I mean your mother and I...");
+	text = hoa_system.Translate("Bronann, there is something that I have to tell you. We've been fearing for this moment. I mean your mother and I...");
 	dialogue:AddLine(text, carson);
 	text = hoa_system.Translate("They're coming!");
 	dialogue:AddLineEvent(text, herth, "", "Quest2: Carson looks at Herth");
@@ -790,11 +790,11 @@ function _CreateEvents()
 	dialogue:AddLineEmote(text, kalya, "sweat drop");
 	text = hoa_system.Translate("Kalya, the army is coming. I'll deal with them, you, go and find Orlinn as fast as possible.");
 	dialogue:AddLineEmote(text, herth, "thinking dots");
-	text = hoa_system.Translate("Gosh! But you might be hurt!!");
+	text = hoa_system.Translate("But you might get hurt!");
 	dialogue:AddLineEmote(text, kalya, "exclamation");
-	text = hoa_system.Translate("No, don't worry. We'll simply talk and they'll move on. You know what you have to do, right?");
+	text = hoa_system.Translate("No, don't worry. We'll simply talk to them and they'll move on. You know what you have to do, right?");
 	dialogue:AddLine(text, herth);
-	text = hoa_system.Translate("Herth, we both know It'll likely...");
+	text = hoa_system.Translate("Herth, we both know it'll likely...");
 	dialogue:AddLine(text, kalya);
 	text = hoa_system.Translate("Do as I say and it'll be alright.");
 	dialogue:AddLine(text, herth);
@@ -812,11 +812,11 @@ function _CreateEvents()
 	dialogue:AddLineEvent(text, kalya, "", "Bronann is sad");
 	text = hoa_system.Translate("Huh? Hey! But...");
 	dialogue:AddLineEmote(text, bronann, "exclamation");
-	text = hoa_system.Translate("He won't slow you down, believe me, right Bronann?");
+	text = hoa_system.Translate("He won't slow you down, believe me. Right, Bronann?");
 	dialogue:AddLineEvent(text, carson, "", "Quest2: Carson looks at Bronann");
-	text = hoa_system.Translate("But Father!");
+	text = hoa_system.Translate("But father!");
 	dialogue:AddLineEvent(text, kalya, "", "Quest2: Kalya looks at Herth");
-	text = hoa_system.Translate("Carson is right, Kalya. Bronann shall go with you. It's... It's an order.");
+	text = hoa_system.Translate("Carson is right, Kalya. Bronann shall go with you. It's... it's an order.");
 	dialogue:AddLineEmote(text, herth, "thinking dots");
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Quest2: Third part of talk", dialogue);
@@ -844,11 +844,11 @@ function _CreateEvents()
 	dialogue = hoa_map.SpriteDialogue();
 	text = hoa_system.Translate("Gahh... ok.");
 	dialogue:AddLineEvent(text, kalya, "", "Quest2: Carson looks at Bronann");
-	text = hoa_system.Translate("Bronann, take this sword, you'll probably need it there to make your way through.");
+	text = hoa_system.Translate("Bronann, take this sword. You'll probably need it to make your way through there.");
 	dialogue:AddLineEvent(text, carson, "", "Quest2: Show the wooden sword item in front of carson");
 	text = hoa_system.Translate("What? But one minute ago you said...");
 	dialogue:AddLineEmote(text, bronann, "exclamation");
-	text = hoa_system.Translate("I know, but everything has changed. I'll explain you once all that is finished, now go, my son.");
+	text = hoa_system.Translate("I know, but everything has changed. I'll explain it to you once it is all finished. Now go, my son.");
 	dialogue:AddLine(text, carson);
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Quest2: Fourth part of talk", dialogue);
@@ -869,7 +869,7 @@ function _CreateEvents()
 	dialogue = hoa_map.SpriteDialogue();
 	text = hoa_system.Translate("Thanks dad, we'll find him in no time.");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("We shall go now, ... Good luck, both of you.");
+	text = hoa_system.Translate("We shall go now... Good luck, both of you.");
 	dialogue:AddLineEvent(text, herth, "", "Quest2: Herth looks at Kalya");
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Quest2: Fifth part of talk", dialogue);
@@ -892,7 +892,7 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Good luck, Son.");
+	text = hoa_system.Translate("Good luck, son.");
 	dialogue:AddLine(text, carson);
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Quest2: Carson talks to Bronann once last time", dialogue);
@@ -907,9 +907,9 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Ok, we'll go together, but slow me down, and I'll make you regret it...");
+	text = hoa_system.Translate("Ok, we'll go together. But slow me down and I'll make you regret it...");
 	dialogue:AddLine(text, kalya);
-	text = hoa_system.Translate("Don't worry, we'll find him, ok?");
+	text = hoa_system.Translate("Don't worry, we'll find him. Ok?");
 	dialogue:AddLine(text, bronann);
 	text = hoa_system.Translate("Ok ...");
 	dialogue:AddLine(text, kalya);
@@ -960,34 +960,34 @@ function _CreateEvents()
     EventManager:RegisterEvent(event);
 
     dialogue = hoa_map.SpriteDialogue();
-    text = hoa_system.Translate("By the way, did you ever prepare yourself for such things before?");
+    text = hoa_system.Translate("By the way, did you ever prepare yourself for something like this before?");
     dialogue:AddLine(text, kalya);
     text = hoa_system.Translate("Huh? Well, Orlinn doesn't disappear every day, you know?");
     dialogue:AddLineEmote(text, bronann, "thinking dots");
-    text = hoa_system.Translate("I see ... Then there are two things very important you need to know:");
+    text = hoa_system.Translate("I see... Then there are two very important things that you need to know:");
     dialogue:AddLine(text, kalya);
-    text = hoa_system.Translate("First of all, before going there, you might need a better equipment. Tell me you'll go and see Flora, ok?");
+    text = hoa_system.Translate("First of all before going there, you might need a better equipment. Go and see Flora first, ok?");
     dialogue:AddLine(text, kalya);
     text = hoa_system.Translate("Ok.");
     dialogue:AddLine(text, bronann);
-    text = hoa_system.Translate("And tell me you equipped your sword ... If you haven't, open your inventory by pressing the menu key (")
+    text = hoa_system.Translate("And tell me that you equipped your sword ... If you haven't, open your inventory by pressing the menu key (")
            .. InputManager:GetMenuKeyName()
-           .. hoa_system.Translate("), and select 'Equip', then you'll be able to select your sword and add it as your main weapon, ok?");
+           .. hoa_system.Translate("), and select 'Equip'. Then you'll be able to select your sword and add it as your main weapon, ok?");
     dialogue:AddLine(text, kalya);
-    text = hoa_system.Translate("You mean, like, I need to push a key to open my bag??");
+    text = hoa_system.Translate("You mean, like, I need to push a key to open my bag?");
     dialogue:AddLineEmote(text, bronann, "interrogation");
     text = hoa_system.Translate("Nevermind that, just do it.");
     dialogue:AddLine(text, kalya);
-    text = hoa_system.Translate("The second thing is that the one in front of the battle line will lead the group in the forest. "..
-                                "I mean that the person on top of the battle formation will actually appear, the others will stay hidden.");
+    text = hoa_system.Translate("The second thing is that the person in front of the battle line will lead the group in the forest. "..
+                                "By that I mean that the person on the top of the battle formation will actually appear, while the others will stay hidden.");
     dialogue:AddLine(text, kalya);
-    text = hoa_system.Translate("Hmm, right, I'm not sure to get fully what you mean, but ...");
+    text = hoa_system.Translate("Hmm, right. I'm not sure that I fully get what you mean, but...");
     dialogue:AddLine(text, bronann);
-    text = hoa_system.Translate("Rrrr ... Bronann. Just listen.");
+    text = hoa_system.Translate("Rrrr... Bronann. Just listen.");
     dialogue:AddLine(text, kalya);
     text = hoa_system.Translate("Err, wow, ok!");
     dialogue:AddLineEmote(text, bronann, "sweat drop");
-    text = hoa_system.Translate("That will be the case only in certain area. Here in the village, you'll be the one leading, or may you believe that ...");
+    text = hoa_system.Translate("That will be the case only in certain areas. Here in the village, you'll be the one leading, or at least you may believe that ...");
     dialogue:AddLine(text, kalya);
     text = hoa_system.Translate("(Sigh) ... Ok.");
     dialogue:AddLine(text, bronann);
@@ -1121,11 +1121,11 @@ function _UpdateGeorgesDialogue()
     elseif (GlobalManager:DoesEventExist("layna_center", "quest1_pen_given_done") == true
         and GlobalManager:DoesEventExist("story", "quest1_barley_meal_done") == false) then
         dialogue = hoa_map.SpriteDialogue();
-        text = hoa_system.Translate("In fact, the barley meal was for Lilly.");
+        text = hoa_system.Translate("Actually, the barley meal was for Lilly.");
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("!! What?");
         dialogue:AddLineEmote(text, bronann, "exclamation");
-        text = hoa_system.Translate("Don't thank me for that, it's my pleasure.");
+        text = hoa_system.Translate("Don't thank me for that. It's my pleasure.");
         dialogue:AddLine(text, georges);
         DialogueManager:AddDialogue(dialogue);
         georges:AddDialogueReference(dialogue);
@@ -1136,13 +1136,13 @@ function _UpdateGeorgesDialogue()
         dialogue = hoa_map.SpriteDialogue();
         text = hoa_system.Translate("Here it is, Georges.");
         dialogue:AddLine(text, bronann);
-        text = hoa_system.Translate("You're the nicest of all, Bronnan. I well tell everyone how brave you...");
+        text = hoa_system.Translate("You're the nicest person I know, Bronnan. I well tell everyone how brave you...");
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("(Sigh...) Georges!");
         dialogue:AddLine(text, bronann);
-        text = hoa_system.Translate("Ok ok. Just having a bit of spirit, here, young man.");
+        text = hoa_system.Translate("Ok ok. Just having a bit of spirit, young man.");
         dialogue:AddLine(text, georges);
-        text = hoa_system.Translate("In fact, the barley meal was for Lilly.");
+        text = hoa_system.Translate("Actually, the barley meal was for Lilly.");
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("!! What?");
         dialogue:AddLineEmote(text, bronann, "exclamation");
@@ -1171,15 +1171,15 @@ function _UpdateGeorgesDialogue()
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("Erm, ... Well, I don't hear anything special...");
         dialogue:AddLineEmote(text, bronann, "interrogation");
-        text = hoa_system.Translate("That's the point! Can't you hear the magnificient sound of nature, so invisible to our used hears.");
+        text = hoa_system.Translate("That's the point! Can't you hear the magnificient sound of nature, so invisible to our adapted ears?");
         dialogue:AddLine(text, georges);
-        text = hoa_system.Translate("Huh, please Georges, I wouldn't like to run away like the last time...");
+        text = hoa_system.Translate("Huh, please Georges. I do not want to run away like the last time...");
         dialogue:AddLine(text, bronann);
-        text = hoa_system.Translate("... The incredible and amazing, I could even say, stunning feel in in the wind...");
+        text = hoa_system.Translate("... The incredible and amazing. I could even say, the stunning feel of it in the wind...");
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("Georges, I simply wanted to ask you whether you had some barley meal left!");
         dialogue:AddLineEmote(text, bronann, "sweat drop");
-        text = hoa_system.Translate("Ah I see, well unfortunately, I'm so much sad for the loss I just had, I can't tell you that with the right words.");
+        text = hoa_system.Translate("Ah, I see. Well unfortunately, I'm so sad about a recent loss that, I can't find the right words with which to tell you.");
         dialogue:AddLine(text, georges);
         text = hoa_system.Translate("Huh?");
         dialogue:AddLineEmote(text, bronann, "interrogation");
@@ -1224,7 +1224,7 @@ function _UpdateOrlinnAndKalyaState()
         dialogue = hoa_map.SpriteDialogue();
         text = hoa_system.Translate("I promise I won't bother you again ...");
         dialogue:AddLine(text, orlinn);
-        text = hoa_system.Translate("Don't worry for that, Orlinn, ok?");
+        text = hoa_system.Translate("Don't worry about that, Orlinn. Ok?");
         dialogue:AddLine(text, bronann);
         DialogueManager:AddDialogue(dialogue);
         orlinn:AddDialogueReference(dialogue);
@@ -1245,29 +1245,29 @@ function _UpdateOrlinnAndKalyaState()
         return;
     elseif (GlobalManager:DoesEventExist("layna_center", "quest1_georges_dialogue_done") == true) then
         dialogue = hoa_map.SpriteDialogue();
-        text = hoa_system.Translate("Hi hi hi!!");
+        text = hoa_system.Translate("Hee hee hee!");
         dialogue:AddLine(text, orlinn);
-        text = hoa_system.Translate("What makes you laugh, Orlinn?");
+        text = hoa_system.Translate("What are you laughing about, Orlinn?");
         dialogue:AddLineEmote(text, bronann, "interrogation");
         text = hoa_system.Translate("You'll never find it!");
         dialogue:AddLine(text, orlinn);
         text = hoa_system.Translate("Huh? Wait! Are you talking about Georges' lost pen?");
         dialogue:AddLineEmote(text, bronann, "exclamation");
-        text = hoa_system.Translate("Hi hi hi! Yes!");
+        text = hoa_system.Translate("Hee hee hee! Yes!");
         dialogue:AddLine(text, orlinn);
-        text = hoa_system.Translate("Please tell me more! Have you found it?");
+        text = hoa_system.Translate("Please tell me! Have you found it?");
         dialogue:AddLine(text, bronann);
         text = hoa_system.Translate("Maybe yes, maybe no!");
         dialogue:AddLine(text, orlinn);
-        text = hoa_system.Translate("Oh no, please Orlinn, I need it!");
+        text = hoa_system.Translate("Oh no, please Orlinn! I need it!");
         dialogue:AddLineEmote(text, bronann, "sweat drop");
-        text = hoa_system.Translate("Sure, I'll help you but only if you can catch me!");
+        text = hoa_system.Translate("Sure, I'll help you. But only if you can catch me!");
         dialogue:AddLineEvent(text, orlinn, "", "Quest1: Make Orlinn run and hide");
         DialogueManager:AddDialogue(dialogue);
         orlinn:AddDialogueReference(dialogue);
     else
         dialogue = hoa_map.SpriteDialogue();
-        text = hoa_system.Translate("Heya Bro! Wanna play with me?");
+        text = hoa_system.Translate("Heya bro! Wanna play with me?");
         dialogue:AddLine(text, orlinn);
         DialogueManager:AddDialogue(dialogue);
         orlinn:AddDialogueReference(dialogue);

--- a/dat/maps/layna_village/layna_village_center_shop.lua
+++ b/dat/maps/layna_village/layna_village_center_shop.lua
@@ -348,9 +348,9 @@ function _UpdateFloraDialogue()
 		dialogue = hoa_map.SpriteDialogue();
 		text = hoa_system.Translate("Hi Bronann! What can I do for you?");
 		dialogue:AddLine(text, flora);
-		text = hoa_system.Translate("Hi Flora! Err, could you lend me one of your training sword? I'd like to practise a bit.");
+		text = hoa_system.Translate("Hi Flora! Err, could you lend me one of your training swords? I'd like to practise a bit.");
 		dialogue:AddLine(text, bronann);
-		text = hoa_system.Translate("Ah ah! Sure, as soon as your father will stop lending his sword for you to practise with him. Are you sure everything is alright?");
+		text = hoa_system.Translate("Ah! Sure, as soon as your father will stop lending his sword to you to practise with him. Are you sure everything is alright?");
 		dialogue:AddLine(text, flora);
 		text = hoa_system.Translate("Err, nevermind...");
 		dialogue:AddLineEventEmote(text, bronann, "", "Quest2: Talked to Flora", "sweat drop");
@@ -371,13 +371,13 @@ function _UpdateFloraDialogue()
 		dialogue:AddLine(text, flora);
 		text = hoa_system.Translate("Hi Flora! Do you have some barley meal left?");
 		dialogue:AddLine(text, bronann);
-		text = hoa_system.Translate("Oh sorry, our 'great' poet came earlier and took all of it.");
+		text = hoa_system.Translate("Oh sorry, our 'great' poet came earlier and took all the rest of it.");
 		dialogue:AddLine(text, flora);
-		text = hoa_system.Translate("Times are becoming harder now, we've got less food than before...");
+		text = hoa_system.Translate("Times are becoming harder now. We've got less food than before...");
 		dialogue:AddLine(text, flora);
-		text = hoa_system.Translate("? ... It's the first time I see you in such a worry.");
+		text = hoa_system.Translate("? ... This is the first time that I've see you wear such a worrisome expression.");
 		dialogue:AddLine(text, bronann);
-		text = hoa_system.Translate("Nevermind... Don't worry for me. Just find him and he should give you some, ok?");
+		text = hoa_system.Translate("Nevermind... Don't worry about me. Just find him and he should give you some, ok?");
 		-- Set the quest dialogue as seen by the player.
 		dialogue:AddLineEvent(text, flora, "", "SetQuest1DialogueDone");
 		DialogueManager:AddDialogue(dialogue);

--- a/dat/maps/layna_village/layna_village_kalya_house_exterior.lua
+++ b/dat/maps/layna_village/layna_village_kalya_house_exterior.lua
@@ -375,7 +375,7 @@ function _CreateEvents()
 
 	-- Kalya house locked door event
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Hmm, The door is locked.");
+	text = hoa_system.Translate("Hmm, the door is locked.");
 	dialogue:AddLine(text, bronann);
 	DialogueManager:AddDialogue(dialogue);
 	event = hoa_map.DialogueEvent("Bronann can't enter kalya house", dialogue);

--- a/dat/maps/layna_village/layna_village_kalya_house_path.lua
+++ b/dat/maps/layna_village/layna_village_kalya_house_path.lua
@@ -350,11 +350,11 @@ function _CreateNPCs()
 	Map:AddGroundObject(npc);
 	npc:SetDirection(hoa_map.MapMode.SOUTH);
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Ah! It's nice to see your dear young face around Bronann. Tell a bit about you to an old grandma.");
+	text = hoa_system.Translate("Ah! It's nice to see your dear young face around, Bronann. Come and chat with an old grandma.");
 	dialogue:AddLine(text, npc);
-	text = hoa_system.Translate("Er... Sorry Grandma, I have to go! Maybe later?");
+	text = hoa_system.Translate("Er... Sorry grandma, I have to go! Maybe later?");
 	dialogue:AddLineEmote(text, bronann, "exclamation");
-	text = hoa_system.Translate("Ah ah! You'll surely want to see this young lady living up there. Ah, youngs nowadays...");
+	text = hoa_system.Translate("Ah! You'll surely want to see te young lady living up there. Ah, youngins nowadays...");
 	dialogue:AddLine(text, npc);
 	DialogueManager:AddDialogue(dialogue);
 	npc:AddDialogueReference(dialogue);

--- a/dat/maps/layna_village/layna_village_riverbank.lua
+++ b/dat/maps/layna_village/layna_village_riverbank.lua
@@ -455,7 +455,7 @@ function _CreateNPCs()
 	orlinn:SetMovementSpeed(hoa_map.MapMode.VERY_FAST_SPEED);
 	Map:AddGroundObject(orlinn);
 
-	-- Create an invisible doppelgänger to permit triggering dialogues when the kid is on the cliff.
+	-- Create an invisible doppelg\E4nger to permit triggering dialogues when the kid is on the cliff.
 	orlinn_dialogue_npc = CreateSprite(Map, "Orlinn", 82, 8);
 	orlinn_dialogue_npc:SetCollisionMask(hoa_map.MapMode.NO_COLLISION);
 	orlinn_dialogue_npc:SetVisible(false);
@@ -577,7 +577,7 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("That kid is pretty quick. It's going to take all day long...");
+	text = hoa_system.Translate("That kid is pretty quick. This is going to take all day...");
 	dialogue:AddLineEmote(text, bronann, "sweat drop");
 	DialogueManager:AddDialogue(dialogue);
 
@@ -649,15 +649,15 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Orlinn! How many times did I told you not to bother people around...");
+	text = hoa_system.Translate("Orlinn! How many times did I tell you not to bother other people?");
 	dialogue:AddLine(text, kalya);
-	text = hoa_system.Translate("But sis' I...");
+	text = hoa_system.Translate("But sis! I...");
 	dialogue:AddLineEmote(text, orlinn, "sweat drop");
-	text = hoa_system.Translate("I don't want to hear you!! Now, come!");
+	text = hoa_system.Translate("I don't want to hear it! Now, come!");
 	dialogue:AddLine(text, kalya);
 	text = hoa_system.Translate("Don't blame him, Kalya. Actually, it was...");
 	dialogue:AddLineEmote(text, bronann, "sweat drop");
-	text = hoa_system.Translate("I think I wasn't talking to you, was I?");
+	text = hoa_system.Translate("I don't think I was talking to you, now was I?");
 	dialogue:AddLine(text, kalya);
 	text = hoa_system.Translate("Come Orlinn!");
 	dialogue:AddLine(text, kalya);
@@ -686,11 +686,11 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("I found that pen near the tree behind you. I just wanted to play ...");
+	text = hoa_system.Translate("I found that pen near the tree behind you. I just wanted to play...");
 	dialogue:AddLineEmote(text, orlinn, "sweat drop");
-	text = hoa_system.Translate("Don't worry for that ...");
+	text = hoa_system.Translate("Don't worry about that...");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("Take it, ... Thanks.");
+	text = hoa_system.Translate("Take it... Thanks.");
 	dialogue:AddLine(text, orlinn);
 	DialogueManager:AddDialogue(dialogue);
 
@@ -721,15 +721,15 @@ function _CreateEvents()
 	dialogue:AddLineEvent(text, lilly, "", "Quest1: Hide and Seek3: Bronann turns to Lilly");
 	text = hoa_system.Translate("Er, yes?");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("Don't blame Kalya. She has been having a hard time along with her brother before living here, you know?");
+	text = hoa_system.Translate("Don't blame Kalya. She was having a hard time along with her brother before living here, you know?");
 	dialogue:AddLineEvent(text, lilly, "", "Quest1: Bronann is sad");
-	text = hoa_system.Translate("Well, anyway, she's been ignoring me since the first day I saw her...");
+	text = hoa_system.Translate("Well anyway, she's been ignoring me since the first day I saw her...");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("Eh, you really know nothing about women, do you?");
+	text = hoa_system.Translate("Eh? You really know nothing about women, do you?");
 	dialogue:AddLine(text, lilly);
 	text = hoa_system.Translate("... Huh?");
 	dialogue:AddLineEmote(text, bronann, "interrogation");
-	text = hoa_system.Translate("Eh eh, don't worry about it. It will come in time.");
+	text = hoa_system.Translate("Heh heh, don't worry about it. It will come in time.");
 	dialogue:AddLine(text, lilly);
 	DialogueManager:AddDialogue(dialogue);
 
@@ -793,9 +793,9 @@ function _CreateEvents()
 	EventManager:RegisterEvent(event);
 
 	dialogue = hoa_map.SpriteDialogue();
-	text = hoa_system.Translate("Thanks Lilly.");
+	text = hoa_system.Translate("Thanks, Lilly.");
 	dialogue:AddLine(text, bronann);
-	text = hoa_system.Translate("We're having a shortage of food lately. And I've been taking ... special measures to make sure everyone has enough food.");
+	text = hoa_system.Translate("We're having a shortage of food lately. And I've been taking... special measures to make sure that everyone has enough food.");
 	dialogue:AddLine(text, lilly);
 	text = hoa_system.Translate("Try to enjoy this day, Bronann.");
 	dialogue:AddLine(text, lilly);
@@ -890,17 +890,17 @@ function _SetLillyState()
 		dialogue = hoa_map.SpriteDialogue();
 		text = hoa_system.Translate("What a nice day, isn't it?");
 		dialogue:AddLine(text, lilly);
-		text = hoa_system.Translate("Yes, Lilly, but I've something I have to ask you.");
+		text = hoa_system.Translate("Yes, Lilly. But I have something I have to ask you.");
 		dialogue:AddLine(text, bronann);
 		text = hoa_system.Translate("Sure, just ask.");
 		dialogue:AddLine(text, lilly);
-		text = hoa_system.Translate("Have you still got any barley meal for my parents and me? My mother asked me to get some and I...");
+		text = hoa_system.Translate("Have you still got any barley meal left for my parents and I? My mother asked me to get some and I...");
 		dialogue:AddLine(text, bronann);
 		text = hoa_system.Translate("Unfortunately, I gave it all to Kalya...");
 		dialogue:AddLine(text, lilly);
 		text = hoa_system.Translate("What?!");
 		dialogue:AddLineEmote(text, bronann, "sweat drop");
-		text = hoa_system.Translate("Ah ah! I just wanted to see your reaction. I still have some. Let me go and bring it back to you.");
+		text = hoa_system.Translate("Ah hah! I just wanted to see your reaction. I still have some. Let me go grab it and bring it back to you.");
 		dialogue:AddLineEvent(text, lilly, "", "Quest1: Prepare Lilly for a walk");
 		DialogueManager:AddDialogue(dialogue);
 		lilly :AddDialogueReference(dialogue);
@@ -940,11 +940,11 @@ function _SetOrlinnState()
     elseif (GlobalManager:DoesEventExist("layna_south_entrance", "quest1_orlinn_hide_n_seek1_done") == true) then
         -- Orlinn is on the cliff and is mocking Bronann.
         dialogue = hoa_map.SpriteDialogue();
-        text = hoa_system.Translate("Hi hi hi!");
+        text = hoa_system.Translate("Hee hee hee!");
         dialogue:AddLine(text, orlinn_dialogue_npc);
         text = hoa_system.Translate("Orlinn, how did you get there?");
         dialogue:AddLine(text, bronann);
-        text = hoa_system.Translate("(Giggle) I won't tell you!");
+        text = hoa_system.Translate("(giggle) I won't tell you!");
         dialogue:AddLine(text, orlinn_dialogue_npc);
         DialogueManager:AddDialogue(dialogue);
         orlinn_dialogue_npc:AddDialogueReference(dialogue);

--- a/dat/maps/layna_village/layna_village_south_entrance.lua
+++ b/dat/maps/layna_village/layna_village_south_entrance.lua
@@ -332,19 +332,19 @@ function _CreateNPCs()
 		dialogue:AddLine(text, npc);
 		text = hoa_system.Translate("Hi Herth. I see you've blocked the gate, why so?");
 		dialogue:AddLine(text, bronann);
-		text = hoa_system.Translate("Don't worry too much, I'm just preventing from strangers to sneak in at night.");
+		text = hoa_system.Translate("Don't worry too much. I'm just preventing strangers from being able to sneak in at night.");
 		dialogue:AddLine(text, npc);
-		text = hoa_system.Translate("Some people have been reporting thefts in the villages around lately.");
+		text = hoa_system.Translate("There have been some reports of theft in the villages nearby recently.");
 		dialogue:AddLine(text, npc);
-		text = hoa_system.Translate("Wow, do you think they would come here?");
+		text = hoa_system.Translate("Wow, do you think that they would come here?");
 		dialogue:AddLine(text, bronann);
-		text = hoa_system.Translate("It's a possibility but don't worry too much, ok?");
+		text = hoa_system.Translate("It's a possibility. But don't worry too much, ok?");
 		dialogue:AddLine(text, npc);
 		DialogueManager:AddDialogue(dialogue);
 		npc:AddDialogueReference(dialogue);
 		-- The second time, just repeat the sentence
 		dialogue = hoa_map.SpriteDialogue();
-		text = hoa_system.Translate("It's a possibility but don't worry too much, ok?");
+		text = hoa_system.Translate("It's a possibility. But don't worry too much, ok?");
 		dialogue:AddLine(text, npc);
 		DialogueManager:AddDialogue(dialogue);
 		npc:AddDialogueReference(dialogue);

--- a/dat/objects/arm_armor.lua
+++ b/dat/objects/arm_armor.lua
@@ -38,7 +38,7 @@ end
 
 armor[40001] = {
 	name = hoa_system.Translate("Prismatic ring"),
-	description = hoa_system.Translate("A strange ring protecting from darkness."),
+	description = hoa_system.Translate("A strange ring that protects the wearer from darkness."),
 	icon = "img/icons/armor/jewelry_ring_prismatic.png",
 	physical_defense = 4,
 	metaphysical_defense = 3,

--- a/dat/objects/head_armor.lua
+++ b/dat/objects/head_armor.lua
@@ -38,7 +38,7 @@ end
 
 armor[20001] = {
 	name = hoa_system.Translate("Butterfly hair tong"),
-	description = hoa_system.Translate("An old and finely done piece of jewel."),
+	description = hoa_system.Translate("An old and finely done piece of jewelery."),
 	icon = "img/icons/armor/butterfly_hair_tong.png",
 	physical_defense = 3,
 	metaphysical_defense = 12,

--- a/dat/objects/torso_armor.lua
+++ b/dat/objects/torso_armor.lua
@@ -38,7 +38,7 @@ end
 
 armor[30001] = {
 	name = hoa_system.Translate("Rookie Tunic"),
-	description = hoa_system.Translate("A light soldier rookie tunic worn by new recruits. That one belonged to Bronann's father..."),
+	description = hoa_system.Translate("A light tunic worn by new soldier recruits. This one belonged to Bronann's father..."),
 	icon = "img/icons/armor/rookie_tunic.png",
 	physical_defense = 1,
 	metaphysical_defense = 0,
@@ -48,7 +48,7 @@ armor[30001] = {
 
 armor[30002] = {
 	name = hoa_system.Translate("Old Willow Dress"),
-	description = hoa_system.Translate("An old Willow dress Kalya likes to wear."),
+	description = hoa_system.Translate("An old willow dress that Kalya likes to wear."),
 	icon = "img/icons/armor/willow_dress.png",
 	physical_defense = 1,
 	metaphysical_defense = 0,

--- a/dat/objects/weapons.lua
+++ b/dat/objects/weapons.lua
@@ -38,7 +38,7 @@ end
 
 weapons[10001] = {
 	name = hoa_system.Translate("Wooden Sword"),
-	description = hoa_system.Translate("A sword made of wood and a steel hilt, very good for practising."),
+	description = hoa_system.Translate("A sword made of wood with a steel hilt, very good for practising."),
 	icon = "img/icons/weapons/woodensword.png",
 	physical_attack = 2,
 	metaphysical_attack = 0,

--- a/dat/skills/attack.lua
+++ b/dat/skills/attack.lua
@@ -207,7 +207,7 @@ skills[5] = {
 -- Sylve first attack
 skills[6] = {
 	name = hoa_system.Translate("Dagger Slash"),
-	description = hoa_system.Translate("A simple but efficient thief's dagger attack."),
+	description = hoa_system.Translate("A simple but efficient dagger attack."),
 	sp_required = 0,
 	warmup_time = 1000,
 	cooldown_time = 200,
@@ -230,7 +230,7 @@ skills[6] = {
 -- Attack spells
 skills[7] = {
 	name = hoa_system.Translate("Fire burst"),
-	description = hoa_system.Translate("Makes a small fire burns an enemy."),
+	description = hoa_system.Translate("Creates a small fire that burns an enemy."),
 	sp_required = 7,
 	warmup_time = 4000,
 	cooldown_time = 750,


### PR DESCRIPTION
I went through nearly every line of English text that is seen by the player (covered the entire /dat directory) and updated various lines to read better. The major changes included:
- Fixed all grammatical errors and oddities
- Improved the word order and phrasing of some lines of dialogue
- Made punctuation usage more consistent throughout all the text
- Changed the punctuation in some spoken lines to make better sense (it's very strange for "!" to be followed by "...", for example)

What I did not change:
- No lines of dialogue were added or removed
- Almost all of the expressions ("Ah ah", "Err", etc) remained intact, although I personally think that such language is used much too frequently in the game dialogues so far.
