### PR TITLE
Quest Log as refered to in #10 is added!

### DIFF
--- a/dat/config/quests.lua
+++ b/dat/config/quests.lua
@@ -1,0 +1,13 @@
+-- this is a flat list of all the quest descriptions and their titles.
+-- format should be as follows: ["uniqe_string_id"] = {"title", "description"},
+
+quests = {
+    ["sample_entry1"] = {"A Quest Log Entry", "This is a basic description of the quest"},
+    ["sample_entry2"] = {"Another Quest Log Entry", "Yet another quest log entry"},
+    ["spot_the_dog"] = {"See Spot run!", "he's pretty quick"},
+    ["keep_running_spot"] = {"Spot ran away from home!", "stupid dog..."},
+    ["liar_liar"] = {"TRUST me, this isn't a quest", "I swear!"},
+    ["low_hanging_fruit"] = {"Balls!", "!#&%"},
+    ["get_barley"] = {"Get Some Barely", "Need it for dinner!"},
+    ["find_pen"] = {"Find the pen", "Georges has lost his pen. I need to get it back to him so I can get some barley."},
+}

--- a/dat/maps/layna_village/layna_village_bronanns_home.lua
+++ b/dat/maps/layna_village/layna_village_bronanns_home.lua
@@ -766,6 +766,7 @@ map_functions = {
 	Quest1MotherStartDialogueDone = function()
 		GlobalManager:SetEventValue("bronanns_home", "quest1_mother_start_dialogue_done", 1);
         _UpdateMotherDialogue();
+        GlobalManager:AddQuest("quest1","story","quest1_barley_meal_done","get_barley");
 	end,
 
     Quest1Done = function()

--- a/dat/maps/layna_village/layna_village_center.lua
+++ b/dat/maps/layna_village/layna_village_center.lua
@@ -1297,6 +1297,7 @@ map_functions = {
         -- Makes Orlinn aware that Bronann has talked to Georges.
         _UpdateOrlinnAndKalyaState();
         _UpdateGeorgesDialogue();
+        GlobalManager:AddQuest("quest2","story","quest1_pen_given_done","find_pen");
 	end,
 
     Quest1OrlinnRunAndHide = function()

--- a/src/common/common_bindings.cpp
+++ b/src/common/common_bindings.cpp
@@ -124,6 +124,7 @@ void BindCommonCode()
                     .def("GetSaveLocationY", &GameGlobal::GetSaveLocationY)
                     .def("UnsetSaveLocation", &GameGlobal::UnsetSaveLocation)
                     .def("GetPreviousLocation", &GameGlobal::GetPreviousLocation)
+                    .def("AddQuest", (bool (GameGlobal:: *) (const std::string &, const std::string &, const std::string &, const std::string &)) &GameGlobal::AddQuestLogEntry)
 
                     // Namespace constants
                     .enum_("constants") [

--- a/src/common/gui/textbox.cpp
+++ b/src/common/gui/textbox.cpp
@@ -168,8 +168,8 @@ void TextBox::Draw()
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
     _DrawTextLines(text_xpos, text_ypos, rect);
 
-    if(GUIManager->DEBUG_DrawOutlines() == true)
-        _DEBUG_DrawOutline(text_ypos);
+    if(GUIManager->DEBUG_DrawOutlines())
+        _DEBUG_DrawOutline();
 
     VideoManager->PopState();
 } // void TextBox::Draw()
@@ -630,7 +630,7 @@ void TextBox::_DrawTextLines(float text_x, float text_y, ScreenRect scissor_rect
 
 
 
-void TextBox::_DEBUG_DrawOutline(float text_y)
+void TextBox::_DEBUG_DrawOutline()
 {
     // Stores the positions of the four sides of the rectangle
     float left   = 0.0f;
@@ -647,7 +647,7 @@ void TextBox::_DEBUG_DrawOutline(float text_y)
     // Draw the inner boundaries for each line of text
     uint32 possible_lines = _height / _font_properties->line_skip;
     float line_height = _font_properties->line_skip * -VideoManager->_current_context.coordinate_system.GetVerticalDirection();
-    float line_offset = text_y;
+    float line_offset = top;
 
     for(uint32 i = 1; i <= possible_lines; ++i) {
         line_offset += line_height;

--- a/src/common/gui/textbox.h
+++ b/src/common/gui/textbox.h
@@ -274,11 +274,10 @@ private:
     void _ReformatText();
 
     /** \brief Draws an outline of the element boundaries
-    *** \param text_ypos The y position corresponding to the top of the first line of text
     *** \note This function also draws an outline for each line of text in addition to the textbox
     *** as a whole.
     **/
-    void _DEBUG_DrawOutline(float text_ypos);
+    void _DEBUG_DrawOutline();
 
 }; // class TextBox : public GUIControl
 

--- a/src/modes/menu/menu_views.h
+++ b/src/modes/menu/menu_views.h
@@ -22,6 +22,7 @@
 #ifndef __MENU_VIEWS__
 #define __MENU_VIEWS__
 
+#include "common/global/global.h"
 #include "common/gui/textbox.h"
 
 #include "common/gui/menu_window.h"
@@ -107,6 +108,8 @@ enum CONFIRM_RESULT {
     CONFIRM_RESULT_NOTHING = 2,
     CONFIRM_RESULT_CANCEL = 3,
 };
+
+
 
 /** ****************************************************************************
 *** \brief Represents an individual character window
@@ -233,7 +236,7 @@ private:
     */
     void _InitCategory();
 
-    template <class T> std::vector<hoa_global::GlobalObject *> _GetItemVector(std::vector<T *>* inv);
+    template <class T> std::vector<hoa_global::GlobalObject *> _GetItemVector(std::vector<T *> *inv);
 
 }; // class InventoryWindow : public hoa_video::MenuWindow
 
@@ -287,10 +290,10 @@ public:
     void Update();
 
     /*!
-    * \brief Check if status window is active
-    * \return true if the window is active, false if it's not
+    * \brief Get status window active state
+    * \return the char select value when active, or zero if inactive
     */
-    inline bool IsActive() {
+    inline uint32 GetActiveState() {
         return _char_select_active;
     }
 
@@ -486,6 +489,111 @@ private:
     void _UpdateEquipList();
 
 }; // class EquipWindow : public hoa_video::MenuWindow
+
+/**
+*** \brief Represents the quest log list window on the left side
+*** this holds the options box "list" that players can cycle through to look at
+*** their quests (in Quest Window)
+**/
+
+class QuestListWindow : public hoa_gui::MenuWindow {
+    friend class hoa_menu::MenuMode;
+    friend class QuestState;
+    friend class QuestWindow;
+public:
+    QuestListWindow();
+    ~QuestListWindow(){};
+
+    /*!
+    * \brief Draws window
+    * \return success/failure
+    */
+    void Draw();
+
+    /*!
+    * \brief Performs updates
+    */
+    void Update();
+
+    /*!
+    * \brief Result of whether or not this window is active
+    * \return true if this window is active
+    */
+    bool IsActive()
+    {
+        return _active_box;
+    }
+
+    /*!
+    * \brief switch the active state of this window, and do any associated work
+    * \param activate or deactivate
+    */
+    void Activate(bool new_state);
+
+
+private:
+
+    //! \brief the selectable list of quests
+    hoa_gui::OptionBox _quests_list;
+
+    //! \brief list to quest key index. each index represents the _quest_list selection
+    //! This should be updated on every call the keep synchronized with _quests_list
+    std::vector<std::string> _quest_keys;
+
+    //! \brief indicates whether _quests_list is active or not
+    bool _active_box;
+
+    //! \brief updates the side window quest list based on the current quest log entries
+    void _UpdateQuestList();
+
+    //! \brief determines if the quest is completed based on the given event name
+    bool _IsCompleted(const std::string& complete_event_group, const std::string& complete_event_name) const
+    {
+        return hoa_global::GlobalManager->DoesEventExist(complete_event_group,complete_event_name);
+    }
+};
+/**
+*** \brief Represents the quest log main window
+*** players can view their active quests as well as completed quests when this window is viewing
+**/
+
+class QuestWindow : public hoa_gui::MenuWindow {
+
+    friend class hoa_menu::MenuMode;
+    friend class QuestState;
+
+public:
+
+    QuestWindow();
+    ~QuestWindow(){}
+    /*!
+    * \brief Draws window
+    * \return success/failure
+    */
+    void Draw();
+
+    /*!
+    * \brief Performs updates
+    */
+    void Update();
+
+    /*!
+    * \brief sets the viewing quest key information for the quest. we use this to query the text description
+    */
+    void SetViewingQuestKey(const std::string &quest_key)
+    {
+        _viewing_quest_key = quest_key;
+    }
+
+private:
+    //! \brief the currently viewing quest key. this is set by the Quest List Window through the
+    //! SetViewingQuestKey() function
+    std::string _viewing_quest_key;
+
+    //! \brief sets the display text to be rendered, based on their quest key that is set
+    hoa_gui::TextBox _quest_description;
+
+};
 
 /*!
 * \brief Converts a vector of GlobalItem*, etc. to a vector of GlobalObjects*

--- a/src/utils.h
+++ b/src/utils.h
@@ -521,7 +521,6 @@ hoa_utils::ustring MakeUnicodeString(const std::string &text);
 std::string MakeStandardString(const hoa_utils::ustring &text);
 //@}
 
-
 /** \brief A template function that returns the number of elements in an array
 *** \param array The array of elements
 *** \return The number of elements in the array


### PR DESCRIPTION
The total changes in this push:
- Added Quest view in menu
- Added scrolling of quests and viewing the description
- Quets can be added based on user-preference directly from LUA code /
  logic thanks to an AddQuest lua binding
- Quests will grey-out when completed, and have a "!" on the left if you
  have not read them yet
- dat/config/quests.lua holds the quests. I have added a couple sample and
  some "test" quests there and left them on purpose. You are welcome to add
  / change / destroy as you please, but i wanted there to be a sample in the
  beginning
- added a "Get Barley" quest and "Get Pen" quest as samples into the the
  game

A Couple miscelaneous additions:
- Added "help" information for players when they navigate the menu

A bug fix:
- A bug where selecting Items when there was no inventory has been fixed.
