### PR TITLE
quick bug fix for when a title isnt found

### DIFF
--- a/src/modes/menu/menu_views.cpp
+++ b/src/modes/menu/menu_views.cpp
@@ -1695,6 +1695,7 @@ void QuestListWindow::_UpdateQuestList()
         {
             PRINT_WARNING << "no title found for quest id: "
                             << quest_keys[i] << std::endl;
+            continue;
         }
 
         //set the selected item to read, but ONLY IF we are active in this window


### PR DESCRIPTION
Really quick bug fix.
when a Title isn't found, the code should skip over that quest and print a warning. It currently would cause a crash since it derefs the NULL pointer.
