### PR TITLE
added dynamic cursor offset

### DIFF
--- a/src/modes/menu/menu_views.cpp
+++ b/src/modes/menu/menu_views.cpp
@@ -1595,7 +1595,9 @@ QuestListWindow::QuestListWindow() :
 {
     _quests_list.SetPosition(92.0f, 145.0f);
     _quests_list.SetDimensions(330.0f, 375.0f, 1, 255, 1, 8);
-    _quests_list.SetCursorOffset(-55.0f, -15.0f);
+    //set the cursor offset next to where the exclamation point would be.
+    //this prevents the arrow jumping
+    _quests_list.SetCursorOffset(-75.0f, -15.0f);
     _quests_list.SetTextStyle(TextStyle("text20"));
     _quests_list.SetHorizontalWrapMode(VIDEO_WRAP_MODE_NONE);
     _quests_list.SetVerticalWrapMode(VIDEO_WRAP_MODE_STRAIGHT);


### PR DESCRIPTION
Another minor change.
- Add ed dynamic cursor offset to the quest log window.
  in the current master,  the cursor "jumps" to the left of the quest log entry when the log entry is viewed after the first time. Its quite visible and looks kinda silly. whats happening is:
- when a log is "unread", the left  text start begins with the exclamation point.
- the cursor at this state, is set to the left of the exclamation point as well
- the menu is drawn
- when the log is viewed, the exclamation point is gone but the empty space remains
- the cursor gets set to the left of the actual text, NOT the empty space. 
- the menu is drawn.

This causes a jump between those two frames, and it was bothering me.

I have set it to dynamically scale the offset based on the read / unread state of the log. This keeps the cursor in the same place
