### PR TITLE
added location name and banner to Quests

### DIFF
--- a/dat/config/quests.lua
+++ b/dat/config/quests.lua
@@ -1,6 +1,9 @@
 -- this is a flat list of all the quest descriptions and their titles.
--- format should be as follows: ["unique_string_id"] = {"title", "description", completion_event_group, completion_event_name},
+-- format should be as follows: ["unique_string_id"] = {"title", "description", completion_event_group, completion_event_name, location_name, location_banner_filename},
 -- When the event value of the completion_event_name in the completion_event_group is equal to 1, the quest is considered complete.
+-- location_name and location_banner_filename are optional fields, and they are used to display the quest start location and associated banner image
+-- you can entire '' for these two values, or just leave them out completely. Note: if you define one of these, you MUST define BOTH. they can both be blank, but
+-- both fields MUST exist
 
 -- Use the 'GlobalManager:AddQuestLog("string_id");' luabind script command to add a quest entry in the player's quest log.
 
@@ -12,7 +15,9 @@ quests = {
         -- Description
         hoa_system.Translate("Need some for dinner!\nFlora might have some.\nI should go and have a look in her shop first."),
         -- Group and event for the quest to be complete.
-        "story", "quest1_barley_meal_done"
+        "story", "quest1_barley_meal_done",
+        -- Location name and banner image filename
+        hoa_system.Translate("Village of Layna"), "img/menus/locations/mountain_village.png"
     },
 
     -- Quest id

--- a/src/common/global/global.cpp
+++ b/src/common/global/global.cpp
@@ -721,7 +721,7 @@ uint32 GameGlobal::GetNumberEvents(const std::string &group_name) const
 
 static QuestLogInfo _empty_quest_log_info;
 
-const QuestLogInfo& GameGlobal::GetQuestInfo(const std::string &quest_id)
+QuestLogInfo& GameGlobal::GetQuestInfo(const std::string &quest_id)
 {
     std::map<std::string, QuestLogInfo>::iterator itr = _quest_log_info.find(quest_id);
     if(itr == _quest_log_info.end())
@@ -1679,11 +1679,30 @@ bool GameGlobal::_LoadQuestsScript(const std::string& quests_script_filename)
             continue;
         }
 
-        QuestLogInfo info = QuestLogInfo(MakeUnicodeString(quest_info[0]),
-                                         MakeUnicodeString(quest_info[1]),
-                                         quest_info[2], quest_info[3]);
+        //if description_name and description_banner_filename are not set, just call the standard constructor
+        if(quest_info.size() >= 4 && quest_info.size() < 6)
+        {
+            QuestLogInfo info = QuestLogInfo(MakeUnicodeString(quest_info[0]),
+                                     MakeUnicodeString(quest_info[1]),
+                                     quest_info[2], quest_info[3]);
+            _quest_log_info[quest_id] = info;
+        }
+        //else a fully-formed quest log
+        else if(quest_info.size() == 6)
+        {
+            QuestLogInfo info = QuestLogInfo(MakeUnicodeString(quest_info[0]),
+                                     MakeUnicodeString(quest_info[1]),
+                                     quest_info[2], quest_info[3],
+                                     MakeUnicodeString(quest_info[4]), quest_info[5]);
+            _quest_log_info[quest_id] = info;
+        }
+        //malformed quest log
+        else
+        {
+            PRINT_ERROR << "malformed quest log for id: " << quest_id << std::endl;
+        }
 
-        _quest_log_info[quest_id] = info;
+
     }
 
     quests_script.CloseTable();

--- a/src/common/global/global.h
+++ b/src/common/global/global.h
@@ -195,15 +195,31 @@ private:
 
 // A simple structure used to store quest log system info.
 struct QuestLogInfo {
-    QuestLogInfo(const hoa_utils::ustring& title,
-                 const hoa_utils::ustring& description,
-                 const std::string& completion_event_group,
-                 const std::string& completion_event_name) :
+    QuestLogInfo(const hoa_utils::ustring &title,
+                 const hoa_utils::ustring &description,
+                 const std::string &completion_event_group,
+                 const std::string &completion_event_name) :
         _title(title),
         _description(description),
         _completion_event_group(completion_event_group),
         _completion_event_name(completion_event_name)
     {}
+
+    QuestLogInfo(const hoa_utils::ustring &title,
+                 const hoa_utils::ustring &description,
+                 const std::string &completion_event_group,
+                 const std::string &completion_event_name,
+                 const hoa_utils::ustring &location_name,
+                 const std::string &location_banner_filename) :
+        _title(title),
+        _description(description),
+        _completion_event_group(completion_event_group),
+        _completion_event_name(completion_event_name),
+        _location_name(location_name)
+    {
+        if(!_location_image.Load(location_banner_filename))
+            PRINT_ERROR << "image: " << location_banner_filename << " not able to load" << std::endl;
+    }
 
     QuestLogInfo()
     {}
@@ -215,6 +231,10 @@ struct QuestLogInfo {
     // Internal quest info used to know whether the quest is complete.
     std::string _completion_event_group;
     std::string _completion_event_name;
+
+    // location information
+    hoa_video::StillImage _location_image;
+    hoa_utils::ustring _location_name;
 };
 
 /** *****************************************************************************
@@ -562,7 +582,7 @@ public:
     *** \param quest_id the quest id
     *** \return a reference to the given quest log info or an empty quest log info.
     **/
-    const QuestLogInfo& GetQuestInfo(const std::string &quest_id);
+    QuestLogInfo& GetQuestInfo(const std::string &quest_id);
     //@}
 
     //! \note The overflow condition is not checked here: we just assume it will never occur

--- a/src/modes/menu/menu.cpp
+++ b/src/modes/menu/menu.cpp
@@ -1049,6 +1049,10 @@ void QuestState::_OnEntry(AbstractMenuState *from_state)
 void QuestState::_DrawBottomMenu()
 {
     _menu_mode->_bottom_window.Draw();
+    if(_IsActive())
+    {
+        _menu_mode->_quest_window.DrawBottom();
+    }
 }
 
 /////////////////////////////////////

--- a/src/modes/menu/menu_views.cpp
+++ b/src/modes/menu/menu_views.cpp
@@ -1763,7 +1763,8 @@ void QuestListWindow::_SetupQuestsList() {
 // QuestWindow Class
 ////////////////////////////////////////////////////////////////////////////////
 
-QuestWindow::QuestWindow()
+QuestWindow::QuestWindow():
+    _location_image(NULL)
 {
     //_quest_description.SetOwner(this);
     _quest_description.SetPosition(445, 130);
@@ -1772,6 +1773,12 @@ QuestWindow::QuestWindow()
     _quest_description.SetDisplayMode(VIDEO_TEXT_INSTANT);
     _quest_description.SetTextStyle(TextStyle("text20"));
     _quest_description.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+
+    _location_name.SetPosition(102, 556);
+    _location_name.SetDimensions(500.0f, 50.0f);
+    _location_name.SetTextStyle(TextStyle("title22"));
+    _location_name.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _location_name.SetDisplayText(GlobalManager->GetMapHudName());
 }
 
 void QuestWindow::Draw()
@@ -1782,6 +1789,21 @@ void QuestWindow::Draw()
         _quest_description.Draw();
 }
 
+void QuestWindow::DrawBottom()
+{
+    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, 0);
+    VideoManager->Move(150, 580);
+    // Display Location
+    _location_name.Draw();
+
+    if(_location_image != NULL && _location_image->GetFilename().empty() == false) {
+        VideoManager->SetDrawFlags(VIDEO_X_RIGHT, VIDEO_Y_BOTTOM, 0);
+        VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, 0);
+        VideoManager->Move(390, 685);
+        _location_image->Draw();
+    }
+}
+
 void QuestWindow::Update()
 {
     MenuWindow::Update();
@@ -1789,14 +1811,21 @@ void QuestWindow::Update()
     // Check to see if the id is empty or if the quest doesn't exist. if so, draw an empty space
     if(_viewing_quest_id.empty()) {
         _quest_description.ClearText();
+        _location_name.ClearText();
+        _location_image = NULL;
         return;
     }
 
     // otherwise, put the text description for the quest in
     // Not calling ClearText each time will permit to set up the textbox text only when necessary
-    const QuestLogInfo& info = GlobalManager->GetQuestInfo(_viewing_quest_id);
+    QuestLogInfo& info = GlobalManager->GetQuestInfo(_viewing_quest_id);
     if(!info._description.empty())
+    {
         _quest_description.SetDisplayText(info._description);
+        _location_name.SetDisplayText(info._location_name);
+        _location_image = &info._location_image;
+    }
+
 }
 
 ///////////////////////////

--- a/src/modes/menu/menu_views.h
+++ b/src/modes/menu/menu_views.h
@@ -564,9 +564,15 @@ public:
     ~QuestWindow(){}
     /*!
     * \brief Draws window
-    * \return success/failure
     */
     void Draw();
+
+    /*!
+    * \brief Draws the bottom window information
+    * \note this only draws the location name and banner. we assume the
+    * calling function draws the actual window and frame
+    */
+    void DrawBottom();
 
     /*!
     * \brief Performs updates
@@ -588,6 +594,12 @@ private:
 
     //! \brief sets the display text to be rendered, based on their quest key that is set
     hoa_gui::TextBox _quest_description;
+
+    //! \brief the display text to be rendered for the location name that the quest key is set to
+    hoa_gui::TextBox _location_name;
+
+    //! \brief the currently viewing location image
+    hoa_video::StillImage *_location_image;
 
 };
 


### PR DESCRIPTION
quests.lua now takes an optional location name and location banner filename. This gets displayed in the quest log window bottom pane
