### PR TITLE
Quest Menu Changes

### DIFF
--- a/dat/config/quests.lua
+++ b/dat/config/quests.lua
@@ -1,7 +1,8 @@
 -- this is a flat list of all the quest descriptions and their titles.
--- format should be as follows: ["unique_string_id"] = {"title", "description", completion_event_group, completion_event_name, location_name, location_banner_filename},
+-- format should be as follows: ["unique_string_id"] =
+--      {"title", "description", completion_description, completion_event_group, completion_event_name, location_name, location_banner_filename, location_subname, location_subimage},
 -- When the event value of the completion_event_name in the completion_event_group is equal to 1, the quest is considered complete.
--- location_name and location_banner_filename are optional fields, and they are used to display the quest start location and associated banner image
+-- location_name, location_subname, location_subimage and location_banner_filename are optional fields, and they are used to display the quest start location and associated banner image
 -- All fields can be empty but are required.
 
 -- Use the 'GlobalManager:AddQuestLog("string_id");' luabind script command to add a quest entry in the player's quest log.
@@ -13,10 +14,14 @@ quests = {
         hoa_system.Translate("Get Some Barley Meal"),
         -- Description
         hoa_system.Translate("Mom needs some for dinner!\n \nFlora might have some in her shop. I should go and have a look there first."),
+        -- Completion Description
+        hoa_system.Translate("This quest is completed. Here's how i did it:\nblah blah blah..."),
         -- Group and event for the quest to be complete.
         "story", "quest1_barley_meal_done",
         -- Location name and banner image filename
-        hoa_system.Translate("Village of Layna\n \nBronann's home"), "img/menus/locations/mountain_village.png"
+        hoa_system.Translate("Village of Layna"), "img/menus/locations/mountain_village.png",
+        -- Location sub-name and image filename
+        hoa_system.Translate("Bronann's home"), "img/menus/locations/mountain_village.png",
     },
 
     -- Quest id
@@ -25,10 +30,14 @@ quests = {
         hoa_system.Translate("Find Georges' pen"),
         -- Description
         hoa_system.Translate("In order to know whom Georges gave the rest of barley meal to, I need to get back his lost pen.\n \nHe spoke about losing it near a tree but also told me people in the village might know more..."),
+        -- Completion Description
+        hoa_system.Translate("This quest is completed. Here's how i did it:\nblah blah blah..."),
         -- Group and event for the quest to be complete.
         "layna_center", "quest1_pen_given_done",
         -- Location name and banner image filename
-        hoa_system.Translate("Village of Layna\n \nVillage center"), "img/menus/locations/mountain_village.png"
+        hoa_system.Translate("Village of Layna"), "img/menus/locations/mountain_village.png",
+        -- Location sub-name and image filename
+        hoa_system.Translate("Village center"), "img/menus/locations/mountain_village.png",
     },
 
     -- Quest id
@@ -37,10 +46,14 @@ quests = {
         hoa_system.Translate("Let's go in the woods..."),
         -- Description
         hoa_system.Translate("It's been weeks since I could go outside the village.\n \nThe entrance has been shut with stones, and now they won't even let me go and breath in the only place I could still go before?!?\n \nWhatever, I need a sword just in case and I'll get there alone!"),
+        -- Completion Description
+        hoa_system.Translate("This quest is completed. Here's how i did it:\nblah blah blah..."),
         -- Group and event for the quest to be complete.
         "story", "kalya_has_joined",
         -- Location name and banner image filename
-        hoa_system.Translate("Village of Layna\n \nBronann's home"), "img/menus/locations/mountain_village.png"
+        hoa_system.Translate("Village of Layna"), "img/menus/locations/mountain_village.png",
+        -- Location sub-name and image filename
+        hoa_system.Translate("Bronann's home"), "img/menus/locations/mountain_village.png",
     },
 
     -- Quest id
@@ -49,9 +62,13 @@ quests = {
         hoa_system.Translate("Orlinn might be in danger!"),
         -- Description
         hoa_system.Translate("After seeing that strange light, Orlinn just ran away into the woods. He's just a kid, even if a quick one!\n \nMy own father asked me to go there with Kalya and get him back safe and sound.\n \nI can't let them down!"),
+        -- Completion Description
+        hoa_system.Translate("This quest is completed. Here's how i did it:\nblah blah blah..."),
         -- Group and event for the quest to be complete.
         "none", "none",
         -- Location name and banner image filename
-        hoa_system.Translate("Village of Layna\n \nVillage center"), "img/menus/locations/mountain_village.png"
+        hoa_system.Translate("Village of Layna"), "img/menus/locations/mountain_village.png",
+        -- Location sub-name and image filename
+        hoa_system.Translate("Village center"), "img/menus/locations/mountain_village.png",
     }
 }

--- a/src/common/global/global.cpp
+++ b/src/common/global/global.cpp
@@ -1680,12 +1680,14 @@ bool GameGlobal::_LoadQuestsScript(const std::string& quests_script_filename)
         }
 
         //check whether all fields are there.
-        if(quest_info.size() == 6)
+        if(quest_info.size() == 9)
         {
             QuestLogInfo info = QuestLogInfo(MakeUnicodeString(quest_info[0]),
                                      MakeUnicodeString(quest_info[1]),
-                                     quest_info[2], quest_info[3],
-                                     MakeUnicodeString(quest_info[4]), quest_info[5]);
+                                     MakeUnicodeString(quest_info[2]),
+                                     quest_info[3], quest_info[4],
+                                     MakeUnicodeString(quest_info[5]), quest_info[6],
+                                     MakeUnicodeString(quest_info[7]), quest_info[8]);
             _quest_log_info[quest_id] = info;
         }
         //malformed quest log

--- a/src/common/global/global.h
+++ b/src/common/global/global.h
@@ -197,18 +197,43 @@ private:
 struct QuestLogInfo {
     QuestLogInfo(const hoa_utils::ustring &title,
                  const hoa_utils::ustring &description,
+                 const hoa_utils::ustring &completion_description,
                  const std::string &completion_event_group,
                  const std::string &completion_event_name,
                  const hoa_utils::ustring &location_name,
-                 const std::string &location_banner_filename) :
+                 const std::string &location_banner_filename,
+                 const hoa_utils::ustring &location_subname,
+                 const std::string &location_subimage_filename) :
         _title(title),
         _description(description),
+        _completion_description(completion_description),
         _completion_event_group(completion_event_group),
         _completion_event_name(completion_event_name),
-        _location_name(location_name)
+        _location_name(location_name),
+        _location_subname(location_subname)
     {
         if(!_location_image.Load(location_banner_filename))
+        {
             PRINT_ERROR << "image: " << location_banner_filename << " not able to load" << std::endl;
+            return;
+        }
+        //rescale such that the height is no bigger than 90 pixels. we give ourselves a bit of wiggle room
+        //by actually setting it to 90px, 5 pixel buffer top and bottom, so that we can utilize a potential 100px
+        if(_location_image.GetHeight() > 90.0f)
+            _location_image.SetHeightKeepRatio(90.0f);
+
+        if(!_location_subimage.Load(location_subimage_filename))
+        {
+            PRINT_ERROR << "image: " << location_subimage_filename << " not able to load" << std::endl;
+            return;
+        }
+        //rescale such that the height is no bigger than 90 pixels. we give ourselves a bit of wiggle room
+        //by actually setting it to 90px, 5 pixel buffer top and bottom, so that we can utilize a potential 100px
+        if(_location_subimage.GetHeight() > 90.0f)
+            _location_subimage.SetHeightKeepRatio(90.0f);
+
+
+
     }
 
     QuestLogInfo()
@@ -217,6 +242,8 @@ struct QuestLogInfo {
     // User info about the quest log
     hoa_utils::ustring _title;
     hoa_utils::ustring _description;
+    // Completion description gets added to the quest description when the quest is considered completed
+    hoa_utils::ustring _completion_description;
 
     // Internal quest info used to know whether the quest is complete.
     std::string _completion_event_group;
@@ -224,7 +251,9 @@ struct QuestLogInfo {
 
     // location information
     hoa_video::StillImage _location_image;
+    hoa_video::StillImage _location_subimage;
     hoa_utils::ustring _location_name;
+    hoa_utils::ustring _location_subname;
 };
 
 /** *****************************************************************************

--- a/src/modes/menu/menu_views.h
+++ b/src/modes/menu/menu_views.h
@@ -580,7 +580,9 @@ public:
     void ClearBottom()
     {
         _location_name.ClearText();
+        _location_subname.ClearText();
         _location_image = NULL;
+        _location_subimage = NULL;
     }
 
     /*!
@@ -603,12 +605,16 @@ private:
 
     //! \brief sets the display text to be rendered, based on their quest key that is set
     hoa_gui::TextBox _quest_description;
+    //! \brief sets the display text to be rendered when the quest is completed. this is additional info
+    hoa_gui::TextBox _quest_completion_description;
 
-    //! \brief the display text to be rendered for the location name that the quest key is set to
+    //! \brief the display text to be rendered for the location name and subname that the quest key is set to
     hoa_gui::TextBox _location_name;
+    hoa_gui::TextBox _location_subname;
 
-    //! \brief the currently viewing location image
+    //! \brief the currently viewing location image and location subimage
     hoa_video::StillImage *_location_image;
+    hoa_video::StillImage *_location_subimage;
 
 };
 


### PR DESCRIPTION
as per #97, a couple remaining quest menu changes

Features:
- Added location and sub location image / description support
- Added Completion Descriptions. This is a summary description that shows
  up when you complete the quest (in aqua! oooooOOooo....). note that in
  order to support this the description text box has been changed from 400px
  height to 200px height.

Bug Fix:
- Quest List had some problems with the pointer and "completed" quests. This should now be fixed
- An edge case where a completed quest that had not been read yet was
  causing graphical inconsistencies. This is now fixed
