### PR TITLE
Fix unsafe erase.

### DIFF
--- a/src/modes/map/map_objects.cpp
+++ b/src/modes/map/map_objects.cpp
@@ -760,7 +760,7 @@ void TreasureObject::Update()
         for (; it != _events.end();) {
             // Once the event has finished, we forget it
             if (!event_manager->IsEventActive(*it))
-                _events.erase(it);
+                it = _events.erase(it);
             else
                 ++it;
         }


### PR DESCRIPTION
Another cppcheck hit.

Btw:
I've noticed quite a few vector erase loops. There is an optimization possible, called "swap and pop". It can be applied if the order of items doesn't matter. Of course it only matters if the vectors have got some decent size ( >4 or so ;) ).

Instead of:
for (;it != foo.end();) {
    if (...)
        it = foo.erase(it);
    else
        ++it;
}

you can write:
for (;it != foo.end(); ++it) {
    if (...) {
        *it = foo.back(); 
         foo.pop_back();
         --it; // decrement here if iterator is used in the above condition
    }
}
