### PR TITLE
Fixing a menu wrap around bug.

### DIFF
--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -984,7 +984,7 @@ bool OptionBox::_ChangeSelection(int32 offset, bool horizontal)
                 return false;
         } else  { // The bottom boundary was exceeded
             if(_vertical_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
-                if(row + offset >= _number_rows)
+                if(row + offset > _number_rows)
                     offset -= GetNumberOptions();
             }
             // Make sure horizontal wrapping is allowed if vertical wrap mode is shifting


### PR DESCRIPTION
This is a small patch to fix a bug in the boot menus.

To reproduce in the current code base:

1.) Load the game.
2.) Go to Options -> Key Settings
3.) Click down through the options.  When you get to Pause, instead of going down to Restore Defaults, it goes to Move Right.

This patch fixes that.
