### PR TITLE
MinGW/CodeBlocks precompile utils_pch.h.

### DIFF
--- a/ValyriaTear.cbp
+++ b/ValyriaTear.cbp
@@ -497,7 +497,10 @@
 		<Unit filename="src/utils/utils_numeric.cpp" />
 		<Unit filename="src/utils/utils_numeric.h" />
 		<Unit filename="src/utils/utils_pch.cpp" />
-		<Unit filename="src/utils/utils_pch.h" />
+		<Unit filename="src/utils/utils_pch.h">
+			<Option compile="1" />
+			<Option weight="0" />
+		</Unit>
 		<Unit filename="src/utils/utils_random.cpp" />
 		<Unit filename="src/utils/utils_random.h" />
 		<Unit filename="src/utils/utils_strings.cpp" />


### PR DESCRIPTION
Haven't noticed any build performance changes, is still dominated by linking time (almost 2min on my old dev laptop), at least in debug mode.

Would be great if mac/xcode and linux/cmake would enable it too.
