### PR TITLE
Fix a few spelling nits noted by pedantic lintian.

### DIFF
--- a/doc/valyriatear.6
+++ b/doc/valyriatear.6
@@ -20,7 +20,7 @@ different states of operation in the game.
 Checks all files for integrity
 .TP
 .B \-d, \-\-debug <args>
-enables debug statements in specifed sections of the program,
+enables debug statements in specified sections of the program,
 where <args> can be:
 all, audio, battle, boot, data, global, input, map, mode_manager,
 pause, quit, scene, system, utils, video

--- a/src/common/global/global.h
+++ b/src/common/global/global.h
@@ -481,7 +481,7 @@ public:
     /** \brief Returns a pointer to an event group of the specified name
     *** \param group_name The name of the event group to retreive
     *** \return A pointer to the GlobalEventGroup that represents the event group, or NULL if no event group
-    *** of the specifed name was found
+    *** of the specified name was found
     ***
     *** You can use this method to invoke the public methods of the GlobalEventGroup class. For example, if
     *** we wanted to add a new event "cave_collapse" with a value of 1 to the group event "cave_map", we

--- a/src/main_options.cpp
+++ b/src/main_options.cpp
@@ -149,7 +149,7 @@ void PrintUsage()
     std::cout
             << "usage: "APPSHORTNAME" [options]" << std::endl
             << "  --check/-c        :: checks all files for integrity" << std::endl
-            << "  --debug/-d <args> :: enables debug statements in specifed sections of the" << std::endl
+            << "  --debug/-d <args> :: enables debug statements in specified sections of the" << std::endl
             << "                       program, where <args> can be:" << std::endl
             << "                       all, audio, battle, boot, data, global, input," << std::endl
             << "                       map, mode_manager, pause, quit, scene, system" << std::endl

--- a/src/modes/battle/battle_command.cpp
+++ b/src/modes/battle/battle_command.cpp
@@ -829,7 +829,7 @@ void CommandSupervisor::ConstructMenus()
 void CommandSupervisor::Initialize(BattleCharacter *character)
 {
     if(character == NULL) {
-        IF_PRINT_WARNING(BATTLE_DEBUG) << "function recieved NULL pointer argument" << std::endl;
+        IF_PRINT_WARNING(BATTLE_DEBUG) << "function received NULL pointer argument" << std::endl;
         _state = COMMAND_STATE_INVALID;
         return;
     }


### PR DESCRIPTION
Here's a little fix from cleaning up debian's lintian warnings in pedantic mode.
