### PR TITLE
Fixing a bug with the quest menu.

### DIFF
--- a/src/modes/menu/menu.cpp
+++ b/src/modes/menu/menu.cpp
@@ -589,17 +589,18 @@ void EquipState::_DrawBottomMenu()
 
 void QuestState::Reset()
 {
-    //clear the bottom info
+    // Clear the bottom info.
     _menu_mode->_quest_window.ClearBottom();
-    //automatically go into the quest list window
-    _menu_mode->_quest_list_window.Activate(true);
+
+    // Automatically go into the quest list window.
+    _menu_mode->_quest_list_window._active_box = true;
 }
 
 void QuestState::_ActiveWindowUpdate()
 {
     _menu_mode->_quest_window.Update();
     _menu_mode->_quest_list_window.Update();
-    if(!_IsActive())
+    if (!_IsActive())
         _OnCancel();
 }
 

--- a/src/modes/menu/menu_views.cpp
+++ b/src/modes/menu/menu_views.cpp
@@ -2265,15 +2265,17 @@ QuestListWindow::QuestListWindow() :
 {
     _quests_list.SetPosition(92.0f, 145.0f);
     _quests_list.SetDimensions(330.0f, 375.0f, 1, 255, 1, 8);
+
     //set the cursor offset next to where the exclamation point would be.
     //this prevents the arrow jumping
     _quests_list.SetCursorOffset(-75.0f, -15.0f);
+    _quests_list.SetCursorState(VIDEO_CURSOR_STATE_HIDDEN);
     _quests_list.SetTextStyle(TextStyle("text20"));
     _quests_list.SetHorizontalWrapMode(VIDEO_WRAP_MODE_NONE);
     _quests_list.SetVerticalWrapMode(VIDEO_WRAP_MODE_STRAIGHT);
     _quests_list.SetOptionAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
-    _quests_list.SetCursorState(VIDEO_CURSOR_STATE_HIDDEN);
-    // enable viewing of grey options
+    
+    // Enable the viewing of grey options.
     _quests_list.SetSkipDisabled(false);
 
     _SetupQuestsList();
@@ -2281,48 +2283,53 @@ QuestListWindow::QuestListWindow() :
 
 void QuestListWindow::Draw()
 {
-    // Draw the menu area
+    // Draw the menu area.
     MenuWindow::Draw();
 
-    // Draw the quest log list
+    // Draw the quest log list.
     _quests_list.Draw();
 }
 
 void QuestListWindow::Update()
 {
+    // Display the cursor.
+    _quests_list.SetCursorState(VIDEO_CURSOR_STATE_VISIBLE);
+
     GlobalMedia& media = GlobalManager->Media();
 
-    //if empty, exit out immediatly
-    if(GlobalManager->GetNumberQuestLogEntries() == 0)
+    // If empty, exit out immediatly.
+    if (GlobalManager->GetNumberQuestLogEntries() == 0)
     {
         media.PlaySound("cancel");
         _active_box = false;
         return;
     }
 
-    // quest log is fairly simple. it only responds
-    // to up / down and cancel
-    if(InputManager->CancelPress()) {
+    // The quest log is fairly simple.
+    // It only responds to up / down and cancel.
+    if (InputManager->CancelPress()) {
         _quests_list.InputCancel();
-    } else if(InputManager->UpPress()) {
+    } else if (InputManager->UpPress()) {
         media.PlaySound("bump");
         _quests_list.InputUp();
-    } else if(InputManager->DownPress()) {
+    } else if (InputManager->DownPress()) {
         media.PlaySound("bump");
         _quests_list.InputDown();
     }
 
     uint32 event = _quests_list.GetEvent();
-    // cancel and exit
+
+    // Cancel and exit.
     if (event == VIDEO_OPTION_CONFIRM) {
         media.PlaySound("confirm");
     }
-    else if(event == VIDEO_OPTION_CANCEL) {
+    else if (event == VIDEO_OPTION_CANCEL) {
         _active_box = false;
         _quests_list.SetCursorState(VIDEO_CURSOR_STATE_HIDDEN);
         media.PlaySound("cancel");
     }
-    //standard upate of quest list
+
+    // The standard update of the quest list.
     _UpdateQuestList();
 }
 
@@ -2339,18 +2346,18 @@ void QuestListWindow::_UpdateQuestList()
 {
     if(GlobalManager->GetNumberQuestLogEntries() == 0)
     {
-        //set the QuestWindow key to "NULL", which is actually ""
+        // Set the QuestWindow key to "NULL", which is actually "".
         MenuMode::CurrentInstance()->_quest_window.SetViewingQuestId(std::string());
         return;
     }
 
-    // Get the cursor selection
+    // Get the cursor selection.
     int32 selection = _quests_list.GetSelection();
 
     QuestLogEntry *entry = _quest_entries[selection];
     const std::string& quest_id = entry->GetQuestId();
     ustring title = GlobalManager->GetQuestInfo(quest_id)._title;
-    if(GlobalManager->IsQuestCompleted(quest_id))
+    if (GlobalManager->IsQuestCompleted(quest_id))
     {
         _quests_list.SetOptionText(selection, check_file + title);
         _quests_list.SetCursorOffset(-55.0f, -15.0f);
@@ -2369,26 +2376,11 @@ void QuestListWindow::_UpdateQuestList()
 
     entry->SetRead();
 
-    // Update the list box
+    // Update the list box.
     _quests_list.Update(SystemManager->GetUpdateTime());
 
-    // Set the QuestWindow quest key value to the selected quest
+    // Set the QuestWindow quest key value to the selected quest.
     MenuMode::CurrentInstance()->_quest_window.SetViewingQuestId(quest_id);
-}
-
-void QuestListWindow::Activate(bool new_state)
-{
-    if(new_state)
-    {
-        _quests_list.SetCursorState(VIDEO_CURSOR_STATE_VISIBLE);
-        _quests_list.ResetViewableOption();
-        _quests_list.SetSelection(0);
-    }
-    else
-    {
-        _quests_list.SetCursorState(VIDEO_CURSOR_STATE_HIDDEN);
-    }
-    _active_box = new_state;
 }
 
 void QuestListWindow::_SetupQuestsList() {
@@ -2396,10 +2388,10 @@ void QuestListWindow::_SetupQuestsList() {
     _quest_entries.clear();
     _quest_entries = GlobalManager->GetActiveQuestIds();
 
-    // Recreate the quest option box list as well
+    // Recreate the quest option box list as well.
     _quests_list.ClearOptions();
 
-    // Reorder by sorting via the entry number
+    // Reorder by sorting via the entry number.
     std::sort(_quest_entries.begin(), _quest_entries.end(), sort_by_number_reverse);
 
     // Check whether some should be set as completed.
@@ -2409,7 +2401,7 @@ void QuestListWindow::_SetupQuestsList() {
         const std::string& quest_id = entry->GetQuestId();
         ustring title = GlobalManager->GetQuestInfo(quest_id)._title;
 
-        //completed quest check.
+        // Completed quest check.
         if(GlobalManager->IsQuestCompleted(quest_id)) {
             _quests_list.AddOption(check_file + title);
             _quests_list.EnableOption(i, false);
@@ -2418,7 +2410,8 @@ void QuestListWindow::_SetupQuestsList() {
             _quests_list.AddOption(cross_file + title);
             _quests_list.EnableOption(i, false);
         }
-        //if incomplete, then we check the read status
+
+        // If incomplete, then check the read status.
         else if(entry->IsRead())
             _quests_list.AddOption(spacing + title);
         else

--- a/src/modes/menu/menu_views.h
+++ b/src/modes/menu/menu_views.h
@@ -581,11 +581,10 @@ class QuestListWindow : public vt_gui::MenuWindow {
     friend class QuestWindow;
 public:
     QuestListWindow();
-    ~QuestListWindow(){};
+    ~QuestListWindow() {}
 
     /*!
     * \brief Draws window
-    * \return success/failure
     */
     void Draw();
 
@@ -603,15 +602,7 @@ public:
         return _active_box;
     }
 
-    /*!
-    * \brief switch the active state of this window, and do any associated work
-    * \param activate or deactivate
-    */
-    void Activate(bool new_state);
-
-
 private:
-
     //! \brief the selectable list of quests
     vt_gui::OptionBox _quests_list;
 
@@ -638,9 +629,9 @@ class QuestWindow : public vt_gui::MenuWindow {
     friend class QuestState;
 
 public:
-
     QuestWindow();
-    ~QuestWindow(){}
+    ~QuestWindow() {}
+
     /*!
     * \brief Draws window
     */
@@ -694,7 +685,6 @@ private:
     //! \brief the currently viewing location image and location subimage
     const vt_video::StillImage *_location_image;
     const vt_video::StillImage *_location_subimage;
-
 };
 
 /**


### PR DESCRIPTION
Hi,

This patch fixes a small visual bug with the quest menu.

When you initially open the menu and navigate to "Quests", two cursors will be displayed simultaneously. One cursor to the left of "Quests"; another cursor to the left of the first quest in the quest menu.

This change updates the menu so when you initially navigate to "Quests" only one cursor will be displayed to the left of "Quests". The cursor in the quest menu itself will only display after you select the "Quests" menu.

Let me know if there are any issues or problems.

Thanks.
