### PR TITLE
More silence under valgrind

### DIFF
--- a/src/engine/input.cpp
+++ b/src/engine/input.cpp
@@ -44,6 +44,8 @@ bool INPUT_DEBUG = false;
 InputEngine::InputEngine()
 {
     IF_PRINT_WARNING(INPUT_DEBUG) << "INPUT: InputEngine constructor invoked" << std::endl;
+    memset(&_key, 0, sizeof(_key));
+    memset(&_joystick, 0, sizeof(_joystick));
     _registered_key_press   = false;
     _registered_key_release = false;
 


### PR DESCRIPTION
This patch prevents valgrind messages like this:

==3751== Conditional jump or move depends on uninitialised value(s)
==3751==    at 0x6BBA16: vt_input::InputEngine::_SetNewJoyButton(unsigned char&, unsigned char) (in ./valyriatear)
==3751==    by 0x885BBC: LoadSettings() (in ./valyriatear)
==3751==    by 0x888661: InitializeEngine() (in ./valyriatear)
==3751==    by 0x6031CE: main (in ./valyriatear)
