### PR TITLE
fix memory leak

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -377,7 +377,9 @@ void InitializeEngine() throw(Exception)
 
     // Set the window icon
     // NOTE: Seems to be working only under WinXP for now.
-    SDL_WM_SetIcon(IMG_Load("img/logos/program_icon.png"), NULL);
+    SDL_Surface *pIcon = IMG_Load("img/logos/program_icon.png");
+    SDL_WM_SetIcon(pIcon, NULL);
+    SDL_FreeSurface(pIcon);
 
     // Load all the settings from lua. This includes some engine configuration settings.
     if(!LoadSettings())


### PR DESCRIPTION
valgrind warning:
==3751== 11,956 (88 direct, 11,868 indirect) bytes in 1 blocks are definitely lost in loss record 196 of 196
==3751==    at 0x4C277AB: malloc (in /usr/lib64/valgrind/vgpreload_memcheck-amd64-linux.so)
==3751==    by 0x4E61BF4: SDL_CreateRGBSurface (in /usr/lib64/libSDL-1.2.so.0.11.4)
==3751==    by 0x54F8FAC: IMG_LoadPNG_RW (in /usr/lib64/libSDL_image-1.2.so.0.8.4)
==3751==    by 0x54F4EC7: IMG_LoadTyped_RW (in /usr/lib64/libSDL_image-1.2.so.0.8.4)
==3751==    by 0x888652: InitializeEngine() (in ./valyriatear)
==3751==    by 0x6031CE: main (in ./valyriatear)
