### PR TITLE
Temporary Images Resizing on Resolution Change

### DIFF
--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -1262,11 +1262,13 @@ bool GameOptionsMenuHandler::_ChangeResolution(int32 width, int32 height)
     VideoManager->SetResolution(width, height);
 
     bool ret_value = VideoManager->ApplySettings();
-    if (ret_value)
+    if (ret_value) {
         _has_modified_settings = true;
+    }
 
     _RefreshVideoOptions();
     _SetupResolutionMenu();
+
     return ret_value;
 }
 

--- a/src/engine/mode_manager.cpp
+++ b/src/engine/mode_manager.cpp
@@ -196,13 +196,11 @@ void ModeEngine::Pop(bool fade_out, bool fade_in)
     }
 }
 
-
 // Pop off all game modes
 void ModeEngine::PopAll()
 {
     _pop_count = static_cast<uint32>(_game_stack.size());
 }
-
 
 // Push a new game mode onto the stack
 void ModeEngine::Push(GameMode *gm, bool fade_out, bool fade_in)
@@ -258,16 +256,18 @@ GameMode *ModeEngine::GetTop()
         return _game_stack.back();
 }
 
-
 // Returns a pointer to a game mode on the stack
 GameMode *ModeEngine::Get(uint32 index)
 {
-    if(_game_stack.size() < index)
-        return nullptr;
-    else
-        return _game_stack.at(_game_stack.size() - index);
-}
+    GameMode* result = nullptr;
 
+    assert(_game_stack.size() > index);
+    if (_game_stack.size() > index) {
+        result = _game_stack.at(_game_stack.size() - index - 1);
+    }
+
+    return result;
+}
 
 // Checks if any game modes need to be pushed or popped off the stack, then updates the top stack mode.
 void ModeEngine::Update()

--- a/src/engine/mode_manager.h
+++ b/src/engine/mode_manager.h
@@ -68,8 +68,9 @@ class GameMode
 
 public:
     GameMode();
+
     //! \param mt The mode_type to set the new GameMode object to.
-    GameMode(uint8 mt);
+    explicit GameMode(uint8 mt);
 
     virtual ~GameMode();
 

--- a/src/engine/video/image.h
+++ b/src/engine/video/image.h
@@ -346,7 +346,7 @@ public:
     //! \brief Supply the constructor with "true" if you want this to represent a grayscale image
     explicit StillImage(const bool grayscale = false);
 
-    ~StillImage();
+    virtual ~StillImage() override;
 
     //! \brief Resets the image's properties and removes any references to image data that it maintains
     void Clear();
@@ -863,10 +863,12 @@ class CompositeImage : public ImageDescriptor
 {
 public:
     CompositeImage()
-    {}
+    {
+    }
 
-    ~CompositeImage()
-    {}
+    virtual ~CompositeImage() override
+    {
+    }
 
     //! \brief Removes all image elements held by this class
     void Clear();

--- a/src/engine/video/text.h
+++ b/src/engine/video/text.h
@@ -275,9 +275,9 @@ class TextElement : public ImageDescriptor
 public:
     TextElement();
 
-    TextElement(TextTexture *texture);
+    explicit TextElement(TextTexture *texture);
 
-    ~TextElement();
+    virtual ~TextElement() override;
 
     // ---------- Public members
 
@@ -343,17 +343,17 @@ public:
     TextImage();
 
     //! \brief Constructs rendered string of specified ustring
-    TextImage(const vt_utils::ustring& text, const TextStyle& style = TextStyle());
+    explicit TextImage(const vt_utils::ustring& text, const TextStyle& style = TextStyle());
 
     //! \brief Constructs rendered string of specified std::string
-    TextImage(const std::string& text, const TextStyle& style = TextStyle());
+    explicit TextImage(const std::string& text, const TextStyle& style = TextStyle());
 
     //! \brief Destructs TextImage, lowering reference counts on all contained timages.
-    ~TextImage() {
+    virtual ~TextImage() override {
         Clear();
     }
 
-    TextImage(const TextImage &copy);
+    explicit TextImage(const TextImage &copy);
     TextImage &operator=(const TextImage &copy);
 
     // ---------- Public methods

--- a/src/modes/battle/battle.cpp
+++ b/src/modes/battle/battle.cpp
@@ -1258,8 +1258,6 @@ void BattleMode::_DrawBottomMenu()
     }
 }
 
-
-
 void BattleMode::_DrawStaminaBar()
 {
     // Used to determine whether or not an icon selector graphic needs to be drawn
@@ -1346,8 +1344,14 @@ TransitionToBattleMode::TransitionToBattleMode(BattleMode *BM, bool is_boss):
     _is_boss(is_boss),
     _BM(BM)
 {
-    _screen_capture = VideoManager->CaptureScreen();
-    _screen_capture.SetDimensions(VIDEO_STANDARD_RES_WIDTH, VIDEO_STANDARD_RES_HEIGHT);
+    // Save a copy of the current screen to use as the backdrop.
+    try {
+        _screen_capture = VideoManager->CaptureScreen();
+        _screen_capture.SetDimensions(VIDEO_STANDARD_RES_WIDTH, VIDEO_STANDARD_RES_HEIGHT);
+    }
+    catch (const Exception &e) {
+        IF_PRINT_WARNING(BATTLE_DEBUG) << e.ToString() << std::endl;
+    }
 }
 
 void TransitionToBattleMode::Update()
@@ -1374,9 +1378,10 @@ void TransitionToBattleMode::Update()
 
 void TransitionToBattleMode::Draw()
 {
-    // Draw the battle transition effect
+    // Draw the battle transition effect.
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
+
     VideoManager->Move(0.0f, 0.0f);
     _screen_capture.Draw();
     VideoManager->Move(_position, _position);
@@ -1392,7 +1397,7 @@ void TransitionToBattleMode::Draw()
 void TransitionToBattleMode::Reset()
 {
     // Don't reset a transition in progress
-    if(_transition_timer.IsRunning())
+    if (_transition_timer.IsRunning())
         return;
 
     _position = 0.0f;

--- a/src/modes/map/map_mode.cpp
+++ b/src/modes/map/map_mode.cpp
@@ -230,7 +230,7 @@ void MapMode::Reset()
     // if the game in in the default mode.
     // Still, we won't change the sprite in the middle of a scene for instance.
     // I.e: When going out of the menu mode.
-    if(CurrentState() == private_map::STATE_EXPLORE)
+    if (CurrentState() == private_map::STATE_EXPLORE)
         _object_supervisor->ReloadVisiblePartyMember();
 }
 
@@ -387,6 +387,7 @@ void MapMode::DrawPostEffects()
     VideoManager->PushState();
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_BLEND, VIDEO_X_CENTER, VIDEO_Y_BOTTOM, 0);
+
     // Halos are additive blending made, so they should be applied
     // as post-effects but before the GUI.
     _object_supervisor->DrawLights();
@@ -402,6 +403,7 @@ void MapMode::DrawPostEffects()
     // Draw the treasure menu if necessary
     if(CurrentState() == STATE_TREASURE)
         _treasure_supervisor->Draw();
+
     VideoManager->PopState();
 }
 

--- a/src/modes/menu/menu.cpp
+++ b/src/modes/menu/menu.cpp
@@ -174,7 +174,6 @@ void AbstractMenuState::Draw()
     _OnDrawSideWindow();
     // Draw currently active options box
     _options.Draw();
-
 }
 
 void AbstractMenuState::_OnDrawSideWindow()
@@ -767,10 +766,12 @@ MenuMode::MenuMode() :
     else
         _locale_graphic.SetDimensions(0, 0);
 
+    // Save a copy of the current screen to use as the backdrop.
     try {
         _saved_screen = VideoManager->CaptureScreen();
-    } catch(const Exception &e) {
-        PRINT_ERROR << e.ToString() << std::endl;
+    }
+    catch (const Exception &e) {
+        IF_PRINT_WARNING(MENU_DEBUG) << e.ToString() << std::endl;
     }
 
     GlobalMedia& media = GlobalManager->Media();
@@ -901,7 +902,7 @@ MenuMode::MenuMode() :
 
     _equip_skills_header.SetStyle(TextStyle("title20"));
     _equip_skills_header.SetText(UTranslate("Skills obtained:"));
-} // MenuMode::MenuMode()
+}
 
 MenuMode::~MenuMode()
 {
@@ -927,14 +928,14 @@ MenuMode::~MenuMode()
 
     if(_message_window != nullptr)
         delete _message_window;
-} // MenuMode::~MenuMode()
+}
 
 void MenuMode::Reset()
 {
     _current_instance = this;
 
-    // Reload characters information,
-    // as active status effects may have changed.
+    // Reload the characters' information since
+    // active status effects may have changed.
     ReloadCharacterWindows();
 }
 

--- a/src/modes/pause.cpp
+++ b/src/modes/pause.cpp
@@ -60,6 +60,14 @@ PauseMode::PauseMode(bool quit_state, bool pause_audio) :
     _option_selected(false),
     _options_handler(this)
 {
+    // Save a copy of the current screen to use as the backdrop.
+    try {
+        _screen_capture = VideoManager->CaptureScreen();
+    }
+    catch (const Exception &e) {
+        IF_PRINT_WARNING(PAUSE_DEBUG) << e.ToString() << std::endl;
+    }
+
     // Render the paused string in white text
     _paused_text.SetStyle(TextStyle("title28", Color::white, VIDEO_TEXT_SHADOW_BLACK));
     _paused_text.SetText(UTranslate("Paused"));
@@ -107,8 +115,9 @@ PauseMode::~PauseMode()
 
 void PauseMode::Reset()
 {
-    if(_audio_paused)
+    if (_audio_paused) {
         AudioManager->PauseAudio();
+    }
     else {
         MusicDescriptor *active_music = AudioManager->GetActiveMusic();
         if (active_music) {
@@ -119,13 +128,6 @@ void PauseMode::Reset()
         else {
             _music_volume = 0.0f;
         }
-    }
-
-    // Save a copy of the current screen to use as the backdrop
-    try {
-        _screen_capture = VideoManager->CaptureScreen();
-    } catch(const Exception &e) {
-        IF_PRINT_WARNING(PAUSE_DEBUG) << e.ToString() << std::endl;
     }
 
     VideoManager->DisableFadeEffect();
@@ -205,7 +207,7 @@ void PauseMode::Update()
         media.PlaySound("bump");
         _quit_options.InputDown();
     }
-} // void PauseMode::Update()
+}
 
 void PauseMode::DrawPostEffects()
 {
@@ -213,6 +215,7 @@ void PauseMode::DrawPostEffects()
     VideoManager->SetCoordSys(0.0f, static_cast<float>(VideoManager->GetViewportWidth()),
                               static_cast<float>(VideoManager->GetViewportHeight()), 0.0f);
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
+
     VideoManager->Move(0.0f, 0.0f);
     _screen_capture.Draw(_dim_color);
 

--- a/src/modes/save/save_mode.cpp
+++ b/src/modes/save/save_mode.cpp
@@ -214,11 +214,9 @@ SaveMode::~SaveMode()
 
 }
 
-
-
 void SaveMode::Reset()
 {
-    // Save a copy of the current screen to use as the backdrop
+    // Save a copy of the current screen to use as the backdrop.
     try {
         _screen_capture = VideoManager->CaptureScreen();
     } catch(const Exception &e) {
@@ -228,8 +226,6 @@ void SaveMode::Reset()
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, VIDEO_BLEND, 0);
 }
-
-
 
 void SaveMode::Update()
 {

--- a/src/modes/save/save_mode.h
+++ b/src/modes/save/save_mode.h
@@ -64,7 +64,7 @@ public:
     void Draw();
 
 private:
-    //! The name of the character that this window corresponds) to
+    //! The name of the character that this window corresponds to.
     vt_global::GlobalCharacter *_character;
 
     //! The image of the character

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -75,10 +75,9 @@ ShopMedia::ShopMedia()
     _all_category_names.push_back(UTranslate("Key Items"));
     _all_category_names.push_back(UTranslate("All Wares"));
 
-    // Initialize the character's prites images.
+    // Initialize the characters' sprites' images.
     _InitializeCharacters();
 }
-
 
 void ShopMedia::_InitializeCharacters()
 {
@@ -1057,14 +1056,14 @@ ShopMode::ShopMode() :
     _trade_interface = new TradeInterface();
     _dialogue_supervisor = new vt_common::DialogueSupervisor();
 
+    // Save a copy of the current screen to use as the backdrop.
     try {
         _screen_backdrop = VideoManager->CaptureScreen();
-    } catch(const Exception& e) {
+    }
+    catch (const Exception& e) {
         IF_PRINT_WARNING(SHOP_DEBUG) << e.ToString() << std::endl;
     }
-} // ShopMode::ShopMode()
-
-
+}
 
 ShopMode::~ShopMode()
 {
@@ -1085,8 +1084,6 @@ ShopMode::~ShopMode()
     }
 }
 
-
-
 void ShopMode::Reset()
 {
     _current_instance = this;
@@ -1094,14 +1091,13 @@ void ShopMode::Reset()
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, 0);
 
-    if(IsInitialized() == false)
+    if (IsInitialized() == false) {
         Initialize();
+    }
 
     // Reset potential battle scripts
     GetScriptSupervisor().Reset();
 }
-
-
 
 void ShopMode::Initialize()
 {


### PR DESCRIPTION
Hi,

I uploaded some changes to address to the temporary image resizing issue.  You should be able to change the resolution in the map, shop, and battle modes and the background images will resize appropriately.

I am not sure if this is exactly how you would want to implement this fix.  It is kind of aggressive.  However, I think it illustrates the primary idea of having to iterate up the game state stack; redrawing the game state at each iteration.

In addition, I think there was an implicit conversion causing a memory leak in shop mode.  I uploaded some comments in 'shop.cpp'.  It will probably be easier to look up those comments with the code as context then me trying to explain here.

Let me know what you think and/or if you have any questions or comments.

Thanks.