### PR TITLE
Fixing a memory leak in shop mode.

### DIFF
--- a/src/engine/video/image.h
+++ b/src/engine/video/image.h
@@ -550,10 +550,10 @@ class AnimatedImage : public ImageDescriptor
 
 public:
     //! \brief Supply the constructor with "true" if you want this to represent a grayscale image.
-    AnimatedImage(bool grayscale = false);
+    explicit AnimatedImage(bool grayscale = false);
 
     //! \brief A constructor which also sets the image's dimensions
-    AnimatedImage(float width, float height, bool grayscale = false);
+    explicit AnimatedImage(float width, float height, bool grayscale = false);
 
     //! \brief Resets the image's properties and removes any references to image data that it maintains
     void Clear();

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -87,8 +87,33 @@ void ShopMedia::_InitializeCharacters()
     for(uint32 i = 0; i < characters->size(); ++i) {
         GlobalCharacter *character = characters->at(i);
 
-        if(!character) {
-            _character_sprites.push_back(new AnimatedImage());
+        //
+        // TODO: Remove all of these comments.
+        //
+
+        //
+        // TODO: Someone should review this change.
+        //
+        //       '_character_sprites' stores 'vt_video::AnimatedImage's (not pointers to 'vt_video::AnimatedImage's).
+        //       The original code took 'new AnimatedImage()' as input.  I think the pointer
+        //       was being implicitly converted in a constructor to an 'AnimatedImage'.  I changed the code to what is shown below.
+        //       I think this is what was originally intended.
+        //
+        //
+
+        if (!character) {
+
+            //
+            // TODO: Original code.  It no longer compiles with explicit constructors.
+            //
+            // _character_sprites.push_back(new AnimatedImage());
+            //
+            // I think the compiler was implicitly doing the following:
+            //
+            // _character_sprites.push_back(AnimatedImage((bool)(new AnimatedImage())));
+            //
+
+            _character_sprites.push_back(AnimatedImage());
             continue;
         }
 

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -85,33 +85,9 @@ void ShopMedia::_InitializeCharacters()
     // Grab the sprite frames for all characters in the active party
     std::vector<GlobalCharacter *>* characters = GlobalManager->GetOrderedCharacters();
     for(uint32 i = 0; i < characters->size(); ++i) {
+
         GlobalCharacter *character = characters->at(i);
-
-        //
-        // TODO: Remove all of these comments.
-        //
-
-        //
-        // TODO: Someone should review this change.
-        //
-        //       '_character_sprites' stores 'vt_video::AnimatedImage's (not pointers to 'vt_video::AnimatedImage's).
-        //       The original code took 'new AnimatedImage()' as input.  I think the pointer
-        //       was being implicitly converted in a constructor to an 'AnimatedImage'.  I changed the code to what is shown below.
-        //       I think this is what was originally intended.
-        //
-        //
-
         if (!character) {
-
-            //
-            // TODO: Original code.  It no longer compiles with explicit constructors.
-            //
-            // _character_sprites.push_back(new AnimatedImage());
-            //
-            // I think the compiler was implicitly doing the following:
-            //
-            // _character_sprites.push_back(AnimatedImage((bool)(new AnimatedImage())));
-            //
 
             _character_sprites.push_back(AnimatedImage());
             continue;


### PR DESCRIPTION
Hi,

I broke out this change into a new pull request.

In the original code,

```
_character_sprites.push_back(new AnimatedImage());
```

is actually being compiled as

```
_character_sprites.push_back(AnimatedImage((bool)(new AnimatedImage())));
```

So, the 'new AnimatedImage()' is interpreted by the compiler as a boolean parameter for 'AnimatedImage's first constructor.  A non-null (non-zero) pointer will always convert to a boolean value of 'true', which happens to be what we want in this case.  Everything, except for the small memory leak, just worked out.

Hopefully, this makes some sense as to what was going on. :)

Here's a fun, exaggerated example to play around with if you are bored.  :D

```
class A
{
public:
    A(bool parameter_one = 0) {};
};

class B
{
public:
    B(bool parameter_one = 0) {};
};

void foo()
{
    B b = new B(new A(new A(new A())));
}
```

The 'explicit' keyword prevents things like this.  For single parameter constructors, it is a really good idea to use.

Thanks.