### PR TITLE
Temporary Images Resizing on Resolution Change (Part 2)

### DIFF
--- a/src/engine/video/image.cpp
+++ b/src/engine/video/image.cpp
@@ -20,6 +20,7 @@
 
 #include "engine/script/script_read.h"
 #include "engine/system.h"
+#include "engine/video/color.h"
 
 #include "utils/utils_files.h"
 #include "utils/utils_random.h"
@@ -1701,8 +1702,6 @@ void CompositeImage::AddImage(const StillImage &img, float x_offset, float y_off
         _height = max_y;
 } // void CompositeImage::AddImage(const StillImage& img, float x_offset, float y_offset, float u1, float v1, float u2, float v2)
 
-
-
 // void CompositeImage::ConstructCompositeImage(const std::vector<StillImage>& tiles, const std::vector<std::vector<uint32> >& indeces) {
 // 	if (tiles.empty() == true || indeces.empty() == true) {
 // 		IF_PRINT_WARNING(VIDEO_DEBUG) << "either the tiles or indeces vector function arguments were empty" << std::endl;
@@ -1741,5 +1740,30 @@ void CompositeImage::AddImage(const StillImage &img, float x_offset, float y_off
 // 	}
 // } // void CompositeImage::ConstructCompositeImage(const std::vector<StillImage>& tiles, const std::vector<std::vector<uint32> >& indeces)
 
+void DrawCapturedBackgroundImage(const ImageDescriptor& image, float x, float y)
+{
+    DrawCapturedBackgroundImage(image, x, y, vt_video::Color::white);
+}
+
+void DrawCapturedBackgroundImage(const ImageDescriptor& image, float x, float y, const vt_video::Color& color)
+{
+    int32 width_viewport = VideoManager->GetViewportWidth();
+    int32 height_viewport = VideoManager->GetViewportHeight();
+
+    float width_image = image.GetWidth();
+    float height_image = image.GetHeight();
+
+    assert(width_image > 0.0f);
+    assert(height_image > 0.0f);
+
+    float scale = width_viewport / width_image;
+    if (width_viewport < height_viewport) {
+        scale = height_viewport / height_image;
+    }
+
+    VideoManager->Move(x, y);
+    VideoManager->Scale(scale, scale);
+    image.Draw(color);
+}
 
 }  // namespace vt_video

--- a/src/engine/video/image.h
+++ b/src/engine/video/image.h
@@ -276,7 +276,7 @@ protected:
     bool _unichrome_vertices;
 
     //! \brief Indicates whether the image being loaded should be loaded into a non-volatile area of texture memory.
-    bool  _is_static;
+    bool _is_static;
 
     //! \brief True if this image is grayscale.
     bool _grayscale;
@@ -965,8 +965,23 @@ public:
 private:
     //! \brief A container for each element in the composite image
     std::vector<private_video::ImageElement> _elements;
-}; // class CompositeImage : public ImageDescriptor
+};
 
-}  // namespace vt_video
+/** \brief A helper function to draw a captured, background image.
+*** \param image The captured, background image to draw.
+*** \param x The 'X' position.
+*** \param y The 'Y' position.
+**/
+void DrawCapturedBackgroundImage(const ImageDescriptor& image, float x, float y);
+
+/** \brief A helper function to draw a captured, background image.
+*** \param image The captured, background image to draw.
+*** \param x The 'X' position.
+*** \param y The 'Y' position.
+*** \param color An overlay color.
+**/
+void DrawCapturedBackgroundImage(const ImageDescriptor& image, float x, float y, const vt_video::Color& color);
+
+} // namespace vt_video
 
 #endif // __IMAGE_HEADER__

--- a/src/engine/video/text.h
+++ b/src/engine/video/text.h
@@ -353,7 +353,7 @@ public:
         Clear();
     }
 
-    explicit TextImage(const TextImage &copy);
+    TextImage(const TextImage &copy);
     TextImage &operator=(const TextImage &copy);
 
     // ---------- Public methods

--- a/src/modes/battle/battle.cpp
+++ b/src/modes/battle/battle.cpp
@@ -1379,19 +1379,16 @@ void TransitionToBattleMode::Update()
 void TransitionToBattleMode::Draw()
 {
     // Draw the battle transition effect.
-    VideoManager->SetStandardCoordSys();
-    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
+    int32 width = VideoManager->GetViewportWidth();
+    int32 height = VideoManager->GetViewportHeight();
+    VideoManager->SetCoordSys(0.0f, static_cast<float>(width), 0.0f, static_cast<float>(height));
+    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, VIDEO_BLEND, 0);
 
-    VideoManager->Move(0.0f, 0.0f);
-    _screen_capture.Draw();
-    VideoManager->Move(_position, _position);
-    _screen_capture.Draw(Color(1.0f, 1.0f, 1.0f, 0.3f));
-    VideoManager->Move(-_position, _position);
-    _screen_capture.Draw(Color(1.0f, 1.0f, 1.0f, 0.3f));
-    VideoManager->Move(-_position, -_position);
-    _screen_capture.Draw(Color(1.0f, 1.0f, 1.0f, 0.3f));
-    VideoManager->Move(_position, -_position);
-    _screen_capture.Draw(Color(1.0f, 1.0f, 1.0f, 0.3f));
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, 0.0f, 0.0f);
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, _position, _position, Color(1.0f, 1.0f, 1.0f, 0.3f));
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, -_position, _position, Color(1.0f, 1.0f, 1.0f, 0.3f));
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, -_position, -_position, Color(1.0f, 1.0f, 1.0f, 0.3f));
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, _position, -_position, Color(1.0f, 1.0f, 1.0f, 0.3f));
 }
 
 void TransitionToBattleMode::Reset()

--- a/src/modes/battle/battle_command.cpp
+++ b/src/modes/battle/battle_command.cpp
@@ -648,9 +648,7 @@ CommandSupervisor::CommandSupervisor() :
     if(_category_icons[3].Load("data/gui/battle/item.png") == false)
         PRINT_ERROR << "failed to load category icon" << std::endl;
 
-    _category_text.resize(4);
-    for (TextImage& text_img : _category_text)
-        text_img.SetStyle(TextStyle("title22"));
+    _category_text.resize(4, TextImage("", TextStyle("title22")));
 
     _category_text[0].SetText(Translate("Weapon"));
     _category_text[1].SetText(Translate("Magic"));

--- a/src/modes/menu/menu.cpp
+++ b/src/modes/menu/menu.cpp
@@ -153,13 +153,11 @@ void AbstractMenuState::Draw()
     int32 width = VideoManager->GetViewportWidth();
     int32 height = VideoManager->GetViewportHeight();
     VideoManager->SetCoordSys(0.0f, static_cast<float>(width), 0.0f, static_cast<float>(height));
+    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, VIDEO_BLEND, 0);
 
-    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, 0);
+    vt_video::DrawCapturedBackgroundImage(_menu_mode->_saved_screen, 0.0f, 0.0f);
 
-    VideoManager->Move(0.0f, 0.0f);
-    _menu_mode->_saved_screen.Draw();
-
-    // Restore the Coordinate system (that one is menu mode coordinate system)
+    // Restore the Coordinate system (that one is menu mode coordinate system).
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
 

--- a/src/modes/pause.cpp
+++ b/src/modes/pause.cpp
@@ -216,8 +216,7 @@ void PauseMode::DrawPostEffects()
                               static_cast<float>(VideoManager->GetViewportHeight()), 0.0f);
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
 
-    VideoManager->Move(0.0f, 0.0f);
-    _screen_capture.Draw(_dim_color);
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, 0.0f, 0.0f, _dim_color);
 
     VideoManager->SetStandardCoordSys();
     VideoManager->SetDrawFlags(VIDEO_X_CENTER, VIDEO_Y_CENTER, VIDEO_BLEND, 0);

--- a/src/modes/save/save_mode.cpp
+++ b/src/modes/save/save_mode.cpp
@@ -356,18 +356,17 @@ void SaveMode::Update()
     } // end if (InputManager->DownPress())
 } // void SaveMode::Update()
 
-
-
 void SaveMode::DrawPostEffects()
 {
     // Set the coordinate system for the background and draw
     float width = _screen_capture.GetWidth();
     float height = _screen_capture.GetHeight();
     VideoManager->SetCoordSys(0, width, 0, height);
-    VideoManager->Move(0.0f, 0.0f);
-    _screen_capture.Draw(_dim_color);
+    VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_BOTTOM, VIDEO_BLEND, 0);
 
-    // Re-set the coordinate system for everything else
+    vt_video::DrawCapturedBackgroundImage(_screen_capture, 0.0f, 0.0f, _dim_color);
+
+    // Reset the coordinate system for everything else
     VideoManager->SetStandardCoordSys();
 
     _window.Draw();

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -1300,12 +1300,12 @@ void ShopMode::Update()
 
 void ShopMode::Draw()
 {
-    // Draw the background image. Set the system coordinates to the size of the window (same as the screen backdrop)
+    // Draw the background image. Set the system coordinates to the size of the window (same as the screen backdrop).
     VideoManager->SetCoordSys(0.0f, static_cast<float>(VideoManager->GetViewportWidth()),
                               static_cast<float>(VideoManager->GetViewportHeight()), 0.0f);
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_TOP, VIDEO_BLEND, 0);
-    VideoManager->Move(0.0f, 0.0f);
-    _screen_backdrop.Draw();
+
+    vt_video::DrawCapturedBackgroundImage(_screen_backdrop, 0.0f, 0.0f);
 
     GetScriptSupervisor().DrawBackground();
 


### PR DESCRIPTION
Hi,

Here is the second part of the other pull request.  This pull request contains the actual fix.

Let me know what you think or if you have any questions.  I added some helper functions to "image.h" to consolidate the math into one location.  I just put the functions in there for now.  I was not sure exactly where you would want them.

In addition, I was not able to test the changes in "menu.cpp".  I am not sure where in the game that section of code is called.  Maybe it is never called?

As a side note, when these pull requests get ready to merge, it might be easier to merge the other one first.  Then, I can rebase this pull request on top of it to make things easier.

Thanks.