### PR TITLE
Enabling the heap checker for Visual Studio debug builds.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -455,6 +455,11 @@ void InitializeEngine() throw(Exception)
 // Every great game begins with a single function :)
 int main(int argc, char *argv[])
 {
+#   if defined (_MSC_VER) && defined(_DEBUG)
+        // Enable the debug heap manager for Visual Studio debug builds.
+        _CrtSetDbgFlag(_CRTDBG_ALLOC_MEM_DF | _CRTDBG_LEAK_CHECK_DF);
+#   endif
+
     // When the program exits, the QuitApp() function will be called first, followed by SDL_Quit()
     atexit(SDL_Quit);
     atexit(QuitApp);


### PR DESCRIPTION
Hi,

This is a Visual Studio only call to turn on the debugging output for the debug heap manager.

Most code bases I have worked with leak some amounts of memory when the program starts up and shuts down.  While not the best practice, this is alright as it's a finite amount of memory and this amount does not increase over the execution time of the program.

However, this practice makes using heap diagnostic tools difficult.  You often have to toggle them on and off as you search for critical memory problems.  If you do not, their output will become flooded with data from non-critical memory issues.

Valyria Tear does not suffer from any of these issues.  I can boot the game, immediately turn on the heap checker, play a large section of game, and shut down the game without the heap checker detecting anything wrong.

So, I personally think it should always be enabled while debugging.  There's no real downside at this point.  In addition, if it ever does output something, it probably will be something in our code base that we should fix as our core dependencies seem pretty bullet proof.

Thanks.