### PR TITLE
Attempting to remove the saving and loading of temporary textures.

### DIFF
--- a/src/engine/video/texture_controller.h
+++ b/src/engine/video/texture_controller.h
@@ -59,23 +59,6 @@ public:
 
     bool SingletonInitialize();
 
-    /** \brief Unloads all texture sheets from memory
-    *** \return True only if all texture sheets were successfully unloaded
-    ***
-    *** This leaves the lists of images intact so that they can be reloaded.
-    *** This function is typically invoked when the GL context is changed, so
-    *** that textures may be properly reloaded after the new context has been
-    *** applied.
-    **/
-    bool UnloadTextures();
-
-    /** \brief Reloads all texture sheets that have been unloaded
-    *** \return True only if all texture sheets were successfully reloaded
-    ***
-    *** This is typically called after a GL context change has occurred.
-    **/
-    bool ReloadTextures();
-
     //! \brief Cycles forward to show the next texture sheet
     void DEBUG_NextTexSheet();
 
@@ -130,20 +113,6 @@ private:
     *** \param tex_id The integer handle to the OpenGL texture to delete
      */
     void _DeleteTexture(GLuint tex_id);
-
-    /** \brief Saves all temporary textures.
-    *** \return True only if all temporary textures were successfully saved.
-    ***
-    *** This is used when the GL context is being destroyed.  Perhaps because we are
-    *** switching from windowed to fullscreen.  We must save all textures to disk so
-    *** that we can reload them after the new GL context is created.
-    **/
-    bool _SaveTempTextures();
-
-    /** \brief Deletes any temporary textures.
-    *** \return True if successful.
-    **/
-    bool _DeleteTempTextures();
     //@}
 
     //! \name Texture Sheet Operations

--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -472,43 +472,24 @@ bool VideoEngine::ApplySettings()
         return false;
     }
 
-    // Potentially losing GL context, so unload images first
-    // TODO: Still needed?
-    if(!TextureManager || !TextureManager->UnloadTextures())
-        IF_PRINT_WARNING(VIDEO_DEBUG) << "failed to delete OpenGL textures during a context change" << std::endl;
-
-    // Clear GL state, for OSX compatibility
-    // TODO: Is that still true?
-    DisableBlending();
-    DisableTexture2D();
-    DisableStencilTest();
-    DisableScissoring();
-
-    // Turn off writing to the depth buffer
-    glDepthMask(GL_FALSE);
-
     if (_temp_fullscreen && !_fullscreen) {
         // We want to go in fullscreen mode
         // Get desktop resolution and adapt the current resolution
         int32_t display_index = SDL_GetWindowDisplayIndex(_sdl_window);
         if (display_index < 0) {
-            if(TextureManager)
-                TextureManager->ReloadTextures();
             return false;
         }
+
         SDL_DisplayMode dsp_mode;
         if (SDL_GetDesktopDisplayMode(display_index, &dsp_mode) < 0) {
-            if(TextureManager)
-                TextureManager->ReloadTextures();
             return false;
         }
 
         // Try to apply the fullscreen mode.
         if (SDL_SetWindowFullscreen(_sdl_window, SDL_WINDOW_FULLSCREEN_DESKTOP) < 0) {
-            if(TextureManager)
-                TextureManager->ReloadTextures();
             return false;
         }
+
         // Set the resolution to the current desktop one.
         _temp_width = dsp_mode.w;
         _temp_height = dsp_mode.h;
@@ -516,16 +497,16 @@ bool VideoEngine::ApplySettings()
     else if (!_temp_fullscreen && _fullscreen) {
         // We want to go in windowed mode
         if (SDL_SetWindowFullscreen(_sdl_window, 0) < 0) {
-            if(TextureManager)
-                TextureManager->ReloadTextures();
             return false;
         }
+
         // Go back to windowed mode. Let's not apply a too high resolution
         // in this case to permit the player to still see the menus.
         if (_temp_width > 1024) {
             _temp_width = 1024;
             _temp_height = 768;
         }
+
         SDL_SetWindowSize(_sdl_window, _temp_width, _temp_height);
     }
     else if (_temp_height != _screen_height || _temp_width != _screen_width) {
@@ -559,9 +540,6 @@ bool VideoEngine::ApplySettings()
     // No VSync
     if (_vsync_mode == 0)
         SDL_GL_SetSwapInterval(0);
-
-    if (TextureManager)
-        TextureManager->ReloadTextures();
 
     return true;
 }


### PR DESCRIPTION
Hi,

I noticed the comments about the saving and loading of temporary textures possibly no longer being needed with newer versions of OpenGL.

So, this is the commit to test it. :)

Everything appears to be working properly on Windows.  In addition, these changes allow resolution changes to happen considerably faster.

Let me know what you think.

Thanks.

(Note: This change works around #497.  The code no longer saves any PNGs to disk.  So, that issue would have to reproduced another way.)