### PR TITLE
Fixing an 'off by one' array error.

### DIFF
--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -416,8 +416,8 @@ void ImageMemory::VerticalFlip()
     std::vector<uint8_t> flipped;
     flipped.reserve(_pixels.size());
 
-    for(uint32_t i = 0; i < _height; ++i) {
-        std::vector<uint8_t>::const_iterator start = _pixels.end() - i * _width * GetBytesPerPixel();
+    for (uint32_t i = 1; i <= _height; ++i) {
+        std::vector<uint8_t>::const_iterator start = _pixels.end() - (i * _width * GetBytesPerPixel());
         std::vector<uint8_t>::const_iterator end = start + _width * GetBytesPerPixel();
         flipped.insert(flipped.end(), start, end);
     }


### PR DESCRIPTION
Hi,

This is a small bug fix.

I was testing the screen shot code to try and reproduce #497.  I could not reproduce #497 by taking screen shots.

However, I did notice this small issue and fixed it.

Thanks.