### PR TITLE
Cleaning up some code related to removing temporary images.

### DIFF
--- a/src/engine/video/image_base.h
+++ b/src/engine/video/image_base.h
@@ -286,15 +286,12 @@ public:
     *** to lookup the image in the TextureManager's image map. The list of tags below is sorted from highest
     *** priority (should be at the beginning of the tag) to lowest priority (should be at the end of the tag).
     ***
-    *** -# \<T>: indicates that the image is temporary (created by the video engine itself)
     *** -# \<Xrow_ROWS>: used for multi image elements. "row" is the row number of this particular element
     ***    while "ROWS" is the total number of rows of elements in the multi image
     *** -# \<Ycol_COLS>: used for multi image elements. "col" is the column number of this particular element
     ***    while "COLS" is the total number of columns of elements in the multi image
     *** -# \<G>: used to indicate that this image texture has been converted to grayscale mode
     ***
-    *** \note The \<T> tag and multi image tags can not appear together
-    *** \note The \<T> tag is likely temporary, as its need will later be replaced with procedural image classes
     *** \note Please remember to document new tags here when they are added
     **/
     std::string tags;

--- a/src/engine/video/texture_controller.cpp
+++ b/src/engine/video/texture_controller.cpp
@@ -27,13 +27,6 @@ using namespace vt_video::private_video;
 namespace vt_video
 {
 
-//! \brief The temporary directory.
-const std::string DIRECTORY_TEMPORARY = "temporary/";
-
-//! \brief The temporary texture directory.
-const std::string DIRECTORY_TEMPORARY_TEXTURE = DIRECTORY_TEMPORARY + "texture/";
-
-
 //! \brief A pointer to the texture controller.
 TextureController* TextureManager = nullptr;
 
@@ -439,13 +432,8 @@ bool TextureController::_ReloadImagesToSheet(TexSheet *sheet)
         // Reload a normal image file
         else {
             std::string fname = img->filename;
-            IF_PRINT_DEBUG(VIDEO_DEBUG) << " Reloading image " << fname << std::endl;
 
-            // Check if the image is temporary.
-            // If so, retrieve the image from the temporary image directory.
-            if (img->tags.find("<T>", 0) != img->tags.npos) {
-                fname = vt_utils::GetUserDataPath() + DIRECTORY_TEMPORARY_TEXTURE + fname + ".png";
-            }
+            IF_PRINT_DEBUG(VIDEO_DEBUG) << " Reloading image " << fname << std::endl;
 
             if(load_info.LoadImage(fname) == false) {
                 IF_PRINT_WARNING(VIDEO_DEBUG) << "call to _LoadRawImage() failed" << std::endl;

--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -923,7 +923,8 @@ StillImage VideoEngine::CaptureScreen() throw(Exception)
                            static_cast<int32_t>(viewport_height));
 
     // Create a new ImageTexture with a unique filename for this newly captured screen
-    ImageTexture *new_image = new ImageTexture("capture_screen" + NumberToString(capture_id), "<T>",
+    ImageTexture* new_image = new ImageTexture("capture_screen" + NumberToString(capture_id),
+                                               "",
                                                static_cast<int32_t>(viewport_width),
                                                static_cast<int32_t>(viewport_height));
     new_image->AddReference();
@@ -996,11 +997,13 @@ StillImage VideoEngine::CreateImage(ImageMemory *raw_image, const std::string &i
         }
     }
 
-    //create a new texture image. the next few steps are similar to CaptureImage, so in the future
-    // we may want to do a code-cleanup
-    ImageTexture* new_image = new ImageTexture(image_name, "<T>", raw_image->GetWidth(), raw_image->GetHeight());
+    // Create a new texture image.
+    // The next few steps are similar to CaptureImage.
+    // So, in the future, we may want to do a code cleanup.
+    ImageTexture* new_image = new ImageTexture(image_name, "", raw_image->GetWidth(), raw_image->GetHeight());
     new_image->AddReference();
-    // Create a texture sheet of an appropriate size that can retain the capture
+
+    // Create a texture sheet of an appropriate size that can retain the capture.
     TexSheet* temp_sheet = TextureManager->_CreateTexSheet(RoundUpPow2(raw_image->GetWidth()),
                                                            RoundUpPow2(raw_image->GetHeight()), VIDEO_TEXSHEET_ANY, false);
     VariableTexSheet *sheet = dynamic_cast<VariableTexSheet *>(temp_sheet);


### PR DESCRIPTION
Hi,

I noticed your comments about removing some constants related to the temporary image code removal.

I went through the code and I think the following can be safely removed.

The "\<T\>" tag in 'CaptureScreen' should be safe to remove since that section of code was the heart of the removal change.  None of those textures are written to disk anymore.

In addition, 'CreateImage' is only used to create a procedural mini map.  It does not appear that the mini map texture was ever explicitly written to disk.  So, I think this should be fine as well.

Let me know if there are any issues or problems.

Thanks.