### PR TITLE
Fixing a minor array indexing bug with greyscale textures.

### DIFF
--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -288,31 +288,31 @@ void ImageMemory::ConvertToGrayscale()
     assert(_pixels.size() % bytes_per_pixel == 0);
     if (_pixels.size() % bytes_per_pixel == 0) {
 
-        auto current_position = _pixels.begin();
-        auto end_position = _pixels.end();
+        auto current_pixel = _pixels.begin();
+        auto end_pixel = _pixels.end();
 
-        while (current_position != end_position) {
+        while (current_pixel != end_pixel) {
 
             //
             // Calculate the grayscale value for this pixel based on RGB values: 0.30R + 0.59G + 0.11B.
             //
 
             // Compute the sum.
-            uint8_t sum = 30 * *(current_position + 0) +
-                          59 * *(current_position + 1) +
-                          11 * *(current_position + 2);
+            uint8_t sum = 30 * *(current_pixel + 0) +
+                          59 * *(current_pixel + 1) +
+                          11 * *(current_pixel + 2);
 
             // Scale the sum.
             uint8_t value = static_cast<uint8_t>(sum * 0.01f);
 
             // Store the result.
-            *(current_position + 0) = value;
-            *(current_position + 1) = value;
-            *(current_position + 2) = value;
+            *(current_pixel + 0) = value;
+            *(current_pixel + 1) = value;
+            *(current_pixel + 2) = value;
             // *(i + 3) for RGBA is the alpha value and is left unmodified.
 
-            // Increment the current position.
-            current_position = current_position + bytes_per_pixel;
+            // Increment to the next pixel.
+            current_pixel = current_pixel + bytes_per_pixel;
         }
     }
 }

--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -286,8 +286,8 @@ void ImageMemory::ConvertToGrayscale()
     // We are going to increment through the loop by 'bytes_per_pixel'.
     // So, the size of the array must be divisible by 'bytes_per_pixel'.
     assert(_pixels.size() % bytes_per_pixel == 0);
-    if (_pixels.size() % bytes_per_pixel == 0)
-    {
+    if (_pixels.size() % bytes_per_pixel == 0) {
+
         auto current_position = _pixels.begin();
         auto end_position = _pixels.end();
 

--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -271,21 +271,49 @@ bool ImageMemory::SaveImage(const std::string& filename)
 
 void ImageMemory::ConvertToGrayscale()
 {
-    if(_pixels.empty()) {
+    if (_pixels.empty()) {
         IF_PRINT_WARNING(VIDEO_DEBUG) << "No image data (_pixels is empty)" << std::endl;
         return;
     }
 
-    uint8_t format_bytes = GetBytesPerPixel();
-    uint8_t *end_position = &_pixels[_width * _height * format_bytes];
+    assert(_width > 0);
+    assert(_height > 0);
 
-    for(uint8_t *i = &_pixels[0]; i < end_position; i += format_bytes) {
-        // Compute the grayscale value for this pixel based on RGB values: 0.30R + 0.59G + 0.11B
-        uint8_t value = static_cast<uint8_t>((30 * *(i) + 59 * *(i + 1) + 11 * *(i + 2)) * 0.01f);
-        *i = value;
-        *(i + 1) = value;
-        *(i + 2) = value;
-        // *(i + 3) for RGBA is the alpha value and is left unmodified
+    uint8_t bytes_per_pixel = GetBytesPerPixel();
+
+    assert(_pixels.size() > bytes_per_pixel);
+
+    // We are going to increment through the loop by 'bytes_per_pixel'.
+    // So, the size of the array must be divisible by 'bytes_per_pixel'.
+    assert(_pixels.size() % bytes_per_pixel == 0);
+    if (_pixels.size() % bytes_per_pixel == 0)
+    {
+        auto current_position = _pixels.begin();
+        auto end_position = _pixels.end();
+
+        while (current_position != end_position) {
+
+            //
+            // Calculate the grayscale value for this pixel based on RGB values: 0.30R + 0.59G + 0.11B.
+            //
+
+            // Compute the sum.
+            uint8_t sum = 30 * *(current_position + 0) +
+                          59 * *(current_position + 1) +
+                          11 * *(current_position + 2);
+
+            // Scale the sum.
+            uint8_t value = static_cast<uint8_t>(sum * 0.01f);
+
+            // Store the result.
+            *(current_position + 0) = value;
+            *(current_position + 1) = value;
+            *(current_position + 2) = value;
+            // *(i + 3) for RGBA is the alpha value and is left unmodified.
+
+            // Increment the current position.
+            current_position = current_position + bytes_per_pixel;
+        }
     }
 }
 

--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -309,7 +309,7 @@ void ImageMemory::ConvertToGrayscale()
             *(current_pixel + 0) = value;
             *(current_pixel + 1) = value;
             *(current_pixel + 2) = value;
-            // *(i + 3) for RGBA is the alpha value and is left unmodified.
+            // *(current_pixel + 3) for RGBA is the alpha value and is left unmodified.
 
             // Increment to the next pixel.
             current_pixel = current_pixel + bytes_per_pixel;

--- a/src/engine/video/image_base.cpp
+++ b/src/engine/video/image_base.cpp
@@ -297,10 +297,12 @@ void ImageMemory::ConvertToGrayscale()
             // Calculate the grayscale value for this pixel based on RGB values: 0.30R + 0.59G + 0.11B.
             //
 
+            uint8_t red   = *(current_pixel + 0);
+            uint8_t green = *(current_pixel + 1);
+            uint8_t blue  = *(current_pixel + 2);
+
             // Compute the sum.
-            uint8_t sum = 30 * *(current_pixel + 0) +
-                          59 * *(current_pixel + 1) +
-                          11 * *(current_pixel + 2);
+            uint32_t sum = (30 * red) + (59 * green) + (11 * blue);
 
             // Scale the sum.
             uint8_t value = static_cast<uint8_t>(sum * 0.01f);

--- a/src/modes/boot/boot.cpp
+++ b/src/modes/boot/boot.cpp
@@ -67,7 +67,7 @@ BootMode::BootMode() :
     _debug_script_menu_open = false;
 
     // List the debug scripts
-    _debug_scripts = vt_utils::ListDirectory("data/debug", ".lua");
+    _debug_scripts = vt_utils::ListDirectory("./data/debug", ".lua");
 
     _debug_script_menu.SetPosition(512.0f, 128.0f);
     _debug_script_menu.SetTextStyle(TextStyle("text24"));
@@ -458,6 +458,7 @@ void BootMode::_OnQuit()
 }
 
 #ifdef DEBUG_FEATURES
+
 void BootMode::_DEBUG_OnDebugScriptList()
 {
     _debug_script_menu_open = true;
@@ -469,7 +470,7 @@ void BootMode::_DEBUG_OnDebugScriptRun()
     if (_debug_script_menu.GetNumberOptions() == 0)
         return;
 
-    std::string debug_script = "data/debug/" + _debug_scripts[_debug_script_menu.GetSelection()];
+    std::string debug_script = "./data/debug/" + _debug_scripts[_debug_script_menu.GetSelection()];
     ReadScriptDescriptor read_data;
     read_data.RunScriptFunction(debug_script, "TestFunction", true);
 }

--- a/src/utils/utils_files.cpp
+++ b/src/utils/utils_files.cpp
@@ -90,16 +90,15 @@ bool CleanDirectory(const std::string &dir_name)
     WIN32_FIND_DATAA info = { 0 };
     HANDLE handle = nullptr;
 
-    char file_found[1024];
-    memset(file_found, 0, sizeof(file_found));
-    sprintf(file_found, "%s*.*", dir_name.c_str());
+    std::string file_name = "*.*";
+    std::string first_file = dir_name + "/" + file_name;
 
-    handle = FindFirstFileA(file_found, &info);
+    handle = FindFirstFileA(first_file.c_str(), &info);
     if (handle != INVALID_HANDLE_VALUE) {
         // Remove each file from the directory.
         do {
-            sprintf(file_found, "%s%s", dir_name.c_str(), info.cFileName);
-            DeleteFileA(file_found);
+            file_name = info.cFileName;
+            DeleteFileA(dir_name + "/" + file_name);
         } while (FindNextFileA(handle, &info));
     }
 
@@ -176,20 +175,19 @@ std::vector<std::string> ListDirectory(const std::string &dir_name, const std::s
     WIN32_FIND_DATAA info = { 0 };
     HANDLE handle = nullptr;
 
-    char file_found[1024];
-    memset(file_found, 0, sizeof(file_found));
-    sprintf(file_found, "%s\\*.*", dir_name.c_str());
+    std::string file_name = "*.*";
+    std::string first_file = dir_name + "/" + file_name;
 
-    handle = FindFirstFileA(file_found, &info);
+    handle = FindFirstFileA(first_file.c_str(), &info);
     if (handle != INVALID_HANDLE_VALUE) {
         // List each file from the directory.
         do {
-            std::string file_name(file_found);
+            file_name = info.cFileName;
             if (filter == "") {
-                directoryList.push_back(file_found);
+                directoryList.push_back(file_name);
             }
             else if (file_name.find(filter) != std::string::npos) {
-                directoryList.push_back(file_found);
+                directoryList.push_back(file_name);
             }
         } while (FindNextFileA(handle, &info));
     }


### PR DESCRIPTION
Hi,

This is a minor update to fix an indexing issue.  The following line was out of bounds with the array:

```C++
uint8_t *end_position = &_pixels[_width * _height * format_bytes];
```

"(_width * _height * format_bytes)" is equal to the entire size of the array.  This will be one index too big.

I also updated the looping structure.  I think the 'while' loop is clearer to the reader in this particular case since we are looping in groups of pixels instead of each index sequentially.

Let me know if there are any issues.

Thanks.
