### PR TITLE
Fix determining data dir on Linux

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -515,7 +515,7 @@ int main(int argc, char *argv[])
         chdir(path.c_str());
 #elif (defined(__linux__) || defined(__FreeBSD__) || defined(__OpenBSD__) || defined(SOLARIS)) && !defined(RELEASE_BUILD)
         // Look for data files in DATADIR only if they are not available in the current directory.
-        if(std::ifstream("data/config/settings.lua").bad()) {
+        if(!std::ifstream("data/config/settings.lua").good()) {
             if(chdir(PKG_DATADIR) != 0) {
                 throw Exception("ERROR: failed to change directory to data location", __FILE__, __LINE__, __FUNCTION__);
             }


### PR DESCRIPTION
Use !ifstream.good() instead of ifstream.bad() to check that a file does
not exist.

Fixes GitHub #505