### PR TITLE
Fixing the scrolling animation for option menus.

### DIFF
--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -129,6 +129,7 @@ OptionBox::OptionBox() :
     _first_selection(-1),
     _cursor_state(VIDEO_CURSOR_STATE_VISIBLE),
     _scrolling(false),
+    _scrolling_horizontally(false),
     _scroll_time(0),
     _scroll_direction(0),
     _scrolling_animated(true),
@@ -141,27 +142,52 @@ OptionBox::OptionBox() :
 
 void OptionBox::Update(uint32_t frame_time)
 {
-    _event = 0; // Clear all events
+    // Clear all of the events.
+    _event = 0;
 
-    if(!_scrolling)
-        return;
-
-    if(!_scrolling_animated || _scroll_time > VIDEO_OPTION_SCROLL_TIME) {
-        _scroll_time = 0;
-        _scrolling = false;
-        _scroll_offset = 0.0f;
+    if (!_scrolling) {
         return;
     }
 
     _scroll_time += frame_time;
+    if (_scroll_time > VIDEO_OPTION_SCROLL_TIME) {
+        _scroll_time = VIDEO_OPTION_SCROLL_TIME;
+    }
 
-    // Computes the _scroll_offset independently from the coordinate system
-    _scroll_offset = (_scroll_time / static_cast<float>(VIDEO_OPTION_SCROLL_TIME)) * _cell_height;
-    if(_scroll_direction == -1) // Up
+    // Computes the scroll offset independently from the coordinate system.
+    _scroll_offset = static_cast<int32_t>((static_cast<float>(_scroll_time) / static_cast<float>(VIDEO_OPTION_SCROLL_TIME)) * _cell_height);
+
+    assert(_scroll_direction != 0);
+    if (_scroll_direction < 0) {
+        // Scroll up.
         _scroll_offset = _cell_height - _scroll_offset;
+    }
+
+    if (!_scrolling_animated || _scroll_time >= VIDEO_OPTION_SCROLL_TIME) {
+        _scroll_time = 0;
+        _scrolling = false;
+        _scroll_offset = 0.0f;
+
+        if (_scrolling_horizontally) {
+
+            _number_cell_columns -= 1;
+            assert(_scroll_direction != 0);
+            if (_scroll_direction > 0) {
+                _draw_left_column += 1;
+            }
+        } else {
+
+            _number_cell_rows -= 1;
+            assert(_scroll_direction != 0);
+            if (_scroll_direction > 0) {
+                _draw_top_row += 1;
+            }
+        }
+
+        _scrolling_horizontally = false;
+        _scroll_direction = 0;
+    }
 }
-
-
 
 void OptionBox::Draw()
 {
@@ -181,9 +207,21 @@ void OptionBox::Draw()
 
     // ---------- (1) Determine the edge dimensions of the option box
     left = 0.0f;
-    right = _number_cell_columns * _cell_width;
+
+    if (_scrolling && _scrolling_horizontally) {
+        right = (_number_cell_columns - 1) * _cell_width;
+    } else {
+        right = _number_cell_columns * _cell_width;
+    }
+
     bottom = 0.0f;
-    top = _number_cell_rows * _cell_height;
+
+    if (_scrolling && !_scrolling_horizontally) {
+        top = (_number_cell_rows - 1) * _cell_height;
+    } else {
+        top = _number_cell_rows * _cell_height;
+    }
+
     CalculateAlignedRect(left, right, bottom, top);
 
     CoordSys &cs = VideoManager->_current_context.coordinate_system;
@@ -200,15 +238,14 @@ void OptionBox::Draw()
 
     OptionCellBounds bounds;
     bounds.y_top = top + _scroll_offset;
-    bounds.y_center = bounds.y_top - 0.5f * _cell_height * cs.GetVerticalDirection();
+    bounds.y_center = bounds.y_top - (0.5f * _cell_height * cs.GetVerticalDirection());
     bounds.y_bottom = (bounds.y_center * 2.0f) - bounds.y_top;
-
 
     // ---------- (3) Iterate through all the visible option cells and draw them and the draw cursor
     for(uint32_t row = _draw_top_row; row < _draw_top_row + _number_cell_rows && finished == false; row++) {
 
         bounds.x_left = left;
-        bounds.x_center = bounds.x_left + (0.5f * _cell_width * cs.GetHorizontalDirection());
+        bounds.x_center = bounds.x_left + (0.5f * xoff);
         bounds.x_right = (bounds.x_center * 2.0f) - bounds.x_left;
 
         // Draw the columns of options
@@ -248,7 +285,6 @@ void OptionBox::Draw()
     // ---------- (4) Draw scroll arrows where appropriate
     _DetermineScrollArrows();
     std::vector<StillImage>* arrows = GUIManager->GetScrollArrows();
-
 
     float w, h;
     this->GetDimensions(w, h);
@@ -291,9 +327,7 @@ void OptionBox::Draw()
         GUIControl::_DEBUG_DrawOutline();
 
     VideoManager->PopState();
-} // void OptionBox::Draw()
-
-
+}
 
 void OptionBox::SetDimensions(float width, float height, uint8_t num_cols, uint8_t num_rows, uint8_t cell_cols, uint8_t cell_rows)
 {
@@ -321,8 +355,6 @@ void OptionBox::SetDimensions(float width, float height, uint8_t num_cols, uint8
     _cell_width = _width / cell_cols;
     _cell_height = _height / cell_rows;
 }
-
-
 
 void OptionBox::SetOptions(const std::vector<ustring>& option_text)
 {
@@ -894,6 +926,9 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         bounds_exceeded = true;
     }
 
+    int32_t original_selection = _selection;
+    bool is_wrapped = false;
+
     // Case #1: movement selection is within bounds
     if(bounds_exceeded == false) {
         if(horizontal)
@@ -913,22 +948,29 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         if(col + offset <= 0) {  // The left boundary was exceeded
             if(_horizontal_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
                 offset = _number_columns - 1;
+                is_wrapped = true;
             }
             // Make sure vertical wrapping is allowed if horizontal wrap mode is shifting
             else if(_horizontal_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _vertical_wrap_mode != VIDEO_WRAP_MODE_NONE) {
                 offset += GetNumberOptions();
+                is_wrapped = true;
             } else {
                 return false;
             }
         } else { // The right boundary was exceeded
-            if(_horizontal_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT)
+            if (_horizontal_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
                 offset -= _number_columns;
+                is_wrapped = true;
+            }
             // Make sure vertical wrapping is allowed if horizontal wrap mode is shifting
             else if(_horizontal_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _vertical_wrap_mode != VIDEO_WRAP_MODE_NONE) {
                 offset = 0;
-                _selection++;
-            } else
+                ++_selection;
+                is_wrapped = true;
+            }
+            else {
                 return false;
+            }
         }
         _selection = (_selection + offset) % GetNumberOptions();
     }
@@ -936,23 +978,33 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
     // Case #4: vertical movement with wrapping enabled
     else {
         if(row + offset <= 0) {  // The top boundary was exceeded
-            if(_vertical_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT)
+            if (_vertical_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
                 offset += GetNumberOptions();
-            // Make sure horizontal wrapping is allowed if vertical wrap mode is shifting
-            else if(_vertical_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _horizontal_wrap_mode != VIDEO_WRAP_MODE_NONE)
-                offset += (_number_columns - 1);
-            else
-                return false;
-        } else  { // The bottom boundary was exceeded
-            if(_vertical_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
-                if(row + offset > _number_rows)
-                    offset -= GetNumberOptions();
+                is_wrapped = true;
             }
             // Make sure horizontal wrapping is allowed if vertical wrap mode is shifting
-            else if(_vertical_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _horizontal_wrap_mode != VIDEO_WRAP_MODE_NONE)
-                offset -= (_number_columns - 1);
-            else
+            else if (_vertical_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _horizontal_wrap_mode != VIDEO_WRAP_MODE_NONE) {
+                offset += (_number_columns - 1);
+                is_wrapped = true;
+            }
+            else {
                 return false;
+            }
+        } else  { // The bottom boundary was exceeded
+            if(_vertical_wrap_mode == VIDEO_WRAP_MODE_STRAIGHT) {
+                if (row + offset > _number_rows) {
+                    offset -= GetNumberOptions();
+                }
+                is_wrapped = true;
+            }
+            // Make sure horizontal wrapping is allowed if vertical wrap mode is shifting
+            else if (_vertical_wrap_mode == VIDEO_WRAP_MODE_SHIFTED && _horizontal_wrap_mode != VIDEO_WRAP_MODE_NONE) {
+                offset -= (_number_columns - 1);
+                is_wrapped = true;
+            }
+            else {
+                return false;
+            }
         }
         _selection = (_selection + (offset * _number_columns)) % GetNumberOptions();
     }
@@ -961,77 +1013,107 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
     int32_t selection_row = _selection / _number_columns;
     int32_t selection_col = _selection % _number_columns;
 
-    if((static_cast<uint32_t>(selection_row) < _draw_top_row)) {
-        _scrolling = true;
-        _scroll_time = 0;
-        _draw_top_row = selection_row;
+    if ((static_cast<uint32_t>(selection_row) < _draw_top_row)) {
+        
+        if (is_wrapped) {
 
-        if(selection_row < _scroll_offset)
-            _scroll_direction = -1 * (_scroll_offset - row); // scroll up
-        else
-            _scroll_direction = 1 * (row - _number_rows - _scroll_offset + 1); // scroll down
+            // Scroll up with wrap around.
 
-        _scroll_offset += _scroll_direction;
+            assert(selection_row == 0);
+            _draw_top_row = selection_row;
+        } else {
+
+            // Scroll up normally.
+
+            _scrolling = true;
+            _scrolling_horizontally = false;
+            _scroll_time = 0;
+
+            assert(selection_row >= 0);
+            _draw_top_row = selection_row;
+
+            _scroll_direction = -1;
+            _number_cell_rows += 1;
+        }
     }
 
-    else if((static_cast<uint32_t>(selection_row) >= (_draw_top_row + _number_cell_rows))) {
-        _scrolling = true;
-        _scroll_time = 0;
-        _draw_top_row = selection_row - _number_cell_rows + 1;
+    else if ((static_cast<uint32_t>(selection_row) >= (_draw_top_row + _number_cell_rows))) {
 
-        if(selection_row < _scroll_offset)
-            _scroll_direction = -1 * (_scroll_offset - row); // scroll up
-        else
-            _scroll_direction = 1 * (row - _number_rows - _scroll_offset + 1); // scroll down
+        if (is_wrapped) {
 
-        _scroll_offset += _scroll_direction;
+            // Scroll down with wrap around.
+
+            assert(selection_row - _number_cell_rows + 1 >= 0);
+            _draw_top_row = selection_row - _number_cell_rows + 1;
+        } else {
+
+            // Scroll down normally.
+
+            _scrolling = true;
+            _scrolling_horizontally = false;
+            _scroll_time = 0;
+
+            assert(selection_row - _number_cell_rows >= 0);
+            _draw_top_row = selection_row - _number_cell_rows;
+
+            _scroll_direction = 1;
+            _number_cell_rows += 1;
+        }
     }
 
-    else if((static_cast<uint32_t>(selection_col) < _draw_left_column)) {
-        _scrolling = true;
-        _scroll_time = 0;
-        _draw_left_column = selection_col;
+    else if ((static_cast<uint32_t>(selection_col) < _draw_left_column)) {
 
-        if(selection_row < _scroll_offset)
-            _scroll_direction = -1 * (_scroll_offset - row); // scroll up
-        else
-            _scroll_direction = 1 * (row - _number_rows - _scroll_offset + 1); // scroll down
+        if (is_wrapped) {
 
-        _scroll_offset += _scroll_direction;
+            // Scroll left with wrap around.
+
+            assert(selection_col == 0);
+            _draw_left_column = selection_col;
+        }
+        else {
+
+            // Scroll left normally.
+
+            _scrolling = true;
+            _scrolling_horizontally = true;
+            _scroll_time = 0;
+
+            assert(selection_col >= 0);
+            _draw_left_column = selection_col;
+
+            _scroll_direction = -1;
+            _number_cell_columns += 1;
+        }
     }
 
-    else if((static_cast<uint32_t>(selection_col) >= (_draw_left_column + _number_cell_columns))) {
-        _scrolling = true;
-        _scroll_time = 0;
-        _draw_left_column = selection_col - _number_cell_columns + 1;
+    else if ((static_cast<uint32_t>(selection_col) >= (_draw_left_column + _number_cell_columns))) {
 
-        if(selection_row < _scroll_offset)
-            _scroll_direction = -1 * (_scroll_offset - row); // scroll up
-        else
-            _scroll_direction = 1 * (row - _number_rows - _scroll_offset + 1); // scroll down
+        if (is_wrapped) {
 
-        _scroll_offset += _scroll_direction;
+            // Scroll right with wrap around.
+
+            assert(selection_col - _number_cell_columns + 1 >= 0);
+            _draw_left_column = selection_col - _number_cell_columns + 1;
+        }
+        else {
+
+            // Scroll right normally.
+
+            _scrolling = true;
+            _scrolling_horizontally = true;
+            _scroll_time = 0;
+
+            assert(selection_col - _number_cell_columns >= 0);
+            _draw_left_column = selection_col - _number_cell_columns;
+
+            _scroll_direction = 1;
+            _number_cell_columns += 1;
+        }
     }
-
-    // If the new selection isn't currently being displayed, scroll it into view
-// 	row = _selection / _number_columns;
-// 	if (row < _scroll_offset || row >= _scroll_offset + _number_rows) {
-// 		_scrolling = true;
-// 		_scroll_time = 0;
-//
-// 		if (row < _scroll_offset)
-// 			_scroll_direction = -1 * (_scroll_offset - row); // scroll up
-// 		else
-// 			_scroll_direction = 1 * (row - _number_rows - _scroll_offset + 1); // scroll down
-//
-// 		_scroll_offset += _scroll_direction;
-// 	}
 
     _event = VIDEO_OPTION_SELECTION_CHANGE;
     return true;
-} // bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
-
-
+}
 
 void OptionBox::_SetupAlignment(int32_t xalign, int32_t yalign, const OptionCellBounds &bounds, float &x, float &y)
 {
@@ -1176,9 +1258,7 @@ void OptionBox::_DrawOption(const Option &op, const OptionCellBounds &bounds, fl
         }
         } // switch (op.elements[element].type)
     } // for (int32_t element = 0; element < static_cast<int32_t>(op.elements.size()); element++)
-} // void OptionBox::_DrawOption(const Option& op, const OptionCellBounds &bounds, float scroll_offset, float& left_edge)
-
-
+}
 
 void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float scroll_offset, float left_edge, bool darken)
 {
@@ -1186,21 +1266,12 @@ void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float scroll_offset,
     // The Draw() function (and all helper functions) should be able able to
     // render without knowledge of the private member variable _scroll_offset.
 
-    float x, y;
-
-    // Should never scissor the cursor
-    VideoManager->DisableScissoring();
-
-    float cursor_offset = 0.0f;
-
-    // [phuedx] The scroll_offset has already been calculated and projected on to the current coordinate system
-    if(_scrolling) {
-        cursor_offset = -scroll_offset;
-    }
+    float x = 0.0f;
+    float y = 0.0f;
 
     _SetupAlignment(VIDEO_X_LEFT, _option_yalign, bounds, x, y);
     VideoManager->SetDrawFlags(VIDEO_BLEND, 0);
-    VideoManager->MoveRelative(left_edge + _cursor_xoffset, _cursor_yoffset + cursor_offset);
+    VideoManager->MoveRelative(left_edge + _cursor_xoffset, _cursor_yoffset);
 
     StillImage* default_cursor = GUIManager->GetCursor();
 
@@ -1211,9 +1282,7 @@ void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float scroll_offset,
         default_cursor->Draw();
     else
         default_cursor->Draw(Color(1.0f, 1.0f, 1.0f, 0.5f));
-} // void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float scroll_offset, float left_edge, bool darken)
-
-
+}
 
 void OptionBox::_DEBUG_DrawOutline()
 {

--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -633,8 +633,6 @@ void OptionBox::InputConfirm()
     }
 }
 
-
-
 void OptionBox::InputCancel()
 {
     // Ignore input while scrolling, or if an event has already been logged
@@ -648,22 +646,28 @@ void OptionBox::InputCancel()
         _event = VIDEO_OPTION_CANCEL;
 }
 
-
-
 void OptionBox::InputUp()
 {
     // Ignore input while scrolling, or if an event has already been logged
-    if(_scrolling || _event)
+    if (_scrolling || _event)
         return;
 
-    if(_ChangeSelection(-1, false) == false)
+    int32_t cur_selection = _selection;
+    if (_ChangeSelection(-1, false) == false)
         return;
 
     if (_skip_disabled) {
-        int32_t cur_selection = _selection;
         while (_options[_selection].disabled) {
-            if(_ChangeSelection(-1, false) == false)
+            if (_ChangeSelection(-1, false) == false) {
+
+                // If the final selection is still disabled...
+                if (_options[_selection].disabled) {
+                    // Revert to the original selection.
+                    _selection = cur_selection;
+                }
+
                 return;
+            }
 
             // Let's stop if we made a full turn of options.
             if (_selection == cur_selection)
@@ -674,22 +678,28 @@ void OptionBox::InputUp()
     _event = VIDEO_OPTION_BOUNDS_UP;
 }
 
-
-
 void OptionBox::InputDown()
 {
     // Ignore input while scrolling, or if an event has already been logged
-    if(_scrolling || _event)
+    if (_scrolling || _event)
         return;
 
-    if(_ChangeSelection(1, false) == false)
+    int32_t cur_selection = _selection;
+    if (_ChangeSelection(1, false) == false)
         return;
 
     if (_skip_disabled) {
-        int32_t cur_selection = _selection;
         while (_options[_selection].disabled) {
-            if(_ChangeSelection(1, false) == false)
+            if (_ChangeSelection(1, false) == false) {
+
+                // If the final selection is still disabled...
+                if (_options[_selection].disabled) {
+                    // Revert to the original selection.
+                    _selection = cur_selection;
+                }
+
                 return;
+            }
 
             // Let's stop if we made a full turn of options.
             if (_selection == cur_selection)
@@ -700,22 +710,28 @@ void OptionBox::InputDown()
     _event = VIDEO_OPTION_BOUNDS_DOWN;
 }
 
-
-
 void OptionBox::InputLeft()
 {
     // Ignore input while scrolling, or if an event has already been logged
-    if(_scrolling || _event)
+    if (_scrolling || _event)
         return;
 
-    if(_ChangeSelection(-1, true) == false)
+    int32_t cur_selection = _selection;
+    if (_ChangeSelection(-1, true) == false)
         return;
 
     if (_skip_disabled) {
-        int32_t cur_selection = _selection;
         while (_options[_selection].disabled) {
-            if(_ChangeSelection(-1, true) == false)
+            if (_ChangeSelection(-1, true) == false) {
+
+                // If the final selection is still disabled...
+                if (_options[_selection].disabled) {
+                    // Revert to the original selection.
+                    _selection = cur_selection;
+                }
+
                 return;
+            }
 
             // Let's stop if we made a full turn of options.
             if (_selection == cur_selection)
@@ -726,22 +742,28 @@ void OptionBox::InputLeft()
     _event = VIDEO_OPTION_BOUNDS_LEFT;
 }
 
-
-
 void OptionBox::InputRight()
 {
     // Ignore input while scrolling, or if an event has already been logged
-    if(_scrolling || _event)
+    if (_scrolling || _event)
         return;
 
-    if(_ChangeSelection(1, true) == false)
+    int32_t cur_selection = _selection;
+    if (_ChangeSelection(1, true) == false)
         return;
 
     if (_skip_disabled) {
-        int32_t cur_selection = _selection;
         while (_options[_selection].disabled) {
-            if(_ChangeSelection(1, true) == false)
+            if (_ChangeSelection(1, true) == false) {
+
+                // If the final selection is still disabled...
+                if (_options[_selection].disabled) {
+                    // Revert to the original selection.
+                    _selection = cur_selection;
+                }
+
                 return;
+            }
 
             // Let's stop if we made a full turn of options.
             if (_selection == cur_selection)
@@ -1014,7 +1036,8 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
     int32_t selection_row = _selection / _number_columns;
     int32_t selection_col = _selection % _number_columns;
 
-    if ((static_cast<uint32_t>(selection_row) < _draw_top_row)) {
+    if (!_options[selection_row].disabled &&
+        static_cast<uint32_t>(selection_row) < _draw_top_row) {
         
         if (is_wrapped) {
 
@@ -1038,7 +1061,8 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         }
     }
 
-    else if ((static_cast<uint32_t>(selection_row) >= (_draw_top_row + _number_cell_rows))) {
+    else if (!_options[selection_row].disabled &&
+             static_cast<uint32_t>(selection_row) >= (_draw_top_row + _number_cell_rows)) {
 
         if (is_wrapped) {
 
@@ -1062,7 +1086,8 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         }
     }
 
-    else if ((static_cast<uint32_t>(selection_col) < _draw_left_column)) {
+    else if (!_options[selection_col].disabled &&
+             static_cast<uint32_t>(selection_col) < _draw_left_column) {
 
         if (is_wrapped) {
 
@@ -1087,7 +1112,8 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         }
     }
 
-    else if ((static_cast<uint32_t>(selection_col) >= (_draw_left_column + _number_cell_columns))) {
+    else if (!_options[selection_col].disabled &&
+             static_cast<uint32_t>(selection_col) >= (_draw_left_column + _number_cell_columns)) {
 
         if (is_wrapped) {
 
@@ -1208,7 +1234,7 @@ void OptionBox::_DrawOption(const Option &op, const OptionCellBounds &bounds, fl
             break;
         }
         case VIDEO_OPTION_ELEMENT_IMAGE: {
-            if(op.disabled)
+            if (op.disabled)
                 op.image->Draw(Color::gray);
             else
                 op.image->Draw(Color::white);
@@ -1257,8 +1283,8 @@ void OptionBox::_DrawOption(const Option &op, const OptionCellBounds &bounds, fl
             IF_PRINT_WARNING(VIDEO_DEBUG) << "invalid option element type was present" << std::endl;
             break;
         }
-        } // switch (op.elements[element].type)
-    } // for (int32_t element = 0; element < static_cast<int32_t>(op.elements.size()); element++)
+        }
+    }
 }
 
 void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float left_edge, bool darken)

--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -150,6 +150,8 @@ void OptionBox::Update(uint32_t frame_time)
     }
 
     _scroll_time += frame_time;
+
+    // Clamp the scroll time to prevent over animation.
     if (_scroll_time > VIDEO_OPTION_SCROLL_TIME) {
         _scroll_time = VIDEO_OPTION_SCROLL_TIME;
     }

--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -271,7 +271,7 @@ void OptionBox::Draw()
                 // Also darken when requested
                 if(_cursor_state == VIDEO_CURSOR_STATE_DARKEN)
                     darken = true;
-                _DrawCursor(bounds, _scroll_offset, left_edge, darken);
+                _DrawCursor(bounds, left_edge, darken);
             }
 
             bounds.x_left += xoff;
@@ -928,7 +928,6 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
         bounds_exceeded = true;
     }
 
-    int32_t original_selection = _selection;
     bool is_wrapped = false;
 
     // Case #1: movement selection is within bounds
@@ -1262,7 +1261,7 @@ void OptionBox::_DrawOption(const Option &op, const OptionCellBounds &bounds, fl
     } // for (int32_t element = 0; element < static_cast<int32_t>(op.elements.size()); element++)
 }
 
-void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float scroll_offset, float left_edge, bool darken)
+void OptionBox::_DrawCursor(const OptionCellBounds &bounds, float left_edge, bool darken)
 {
     // [phuedx] In this case the scroll offset is not used, however it should be.
     // The Draw() function (and all helper functions) should be able able to

--- a/src/common/gui/option.cpp
+++ b/src/common/gui/option.cpp
@@ -1052,6 +1052,7 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
             _scrolling = true;
             _scrolling_horizontally = false;
             _scroll_time = 0;
+            _scroll_offset = _cell_height;
 
             assert(selection_row >= 0);
             _draw_top_row = selection_row;
@@ -1077,6 +1078,7 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
             _scrolling = true;
             _scrolling_horizontally = false;
             _scroll_time = 0;
+            _scroll_offset = 0;
 
             assert(selection_row - _number_cell_rows >= 0);
             _draw_top_row = selection_row - _number_cell_rows;
@@ -1103,6 +1105,7 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
             _scrolling = true;
             _scrolling_horizontally = true;
             _scroll_time = 0;
+            _scroll_offset = _cell_width;
 
             assert(selection_col >= 0);
             _draw_left_column = selection_col;
@@ -1129,6 +1132,7 @@ bool OptionBox::_ChangeSelection(int32_t offset, bool horizontal)
             _scrolling = true;
             _scrolling_horizontally = true;
             _scroll_time = 0;
+            _scroll_offset = 0;
 
             assert(selection_col - _number_cell_columns >= 0);
             _draw_left_column = selection_col - _number_cell_columns;

--- a/src/common/gui/option.h
+++ b/src/common/gui/option.h
@@ -649,14 +649,13 @@ private:
     /** \brief Draws the cursor
     *** \param op The option contents to draw within the cell
     *** \param bounds The boundary coordinates for the information cell
-    *** \param scroll_offset A draw offset for when the option box is in the process of scrolling from one option to another
     *** \param left_edge A draw coordiante that represents the left edge of the cell content (as opposed to strictly the cell boundary)
     *** \param darken If true, the cursor image will be drawn with a 50% alpha black color applied
     ***
     *** This method should be called immediately proceeding the _DrawOption method so that it can retrieve the correct value for left_edge
     *** from the cell which should have a cursor drawn.
     **/
-    void _DrawCursor(const private_gui::OptionCellBounds &bounds, float cell_offset, float left_edge, bool darken);
+    void _DrawCursor(const private_gui::OptionCellBounds &bounds, float left_edge, bool darken);
 
     //! \brief Draws an outline of the option box and the inner cell boundaries
     void _DEBUG_DrawOutline();

--- a/src/common/gui/option.h
+++ b/src/common/gui/option.h
@@ -581,8 +581,13 @@ private:
     //! \brief The current cursor state (blinking, visible, hidden, etc)
     CursorState _cursor_state;
 
-    //! \brief Set to true if the box is currently in the middle of scrolling
+    //! \brief Set to true if the box is currently in the middle of scrolling.
     bool _scrolling;
+
+    /** \brief Set to true if the box is currently in the middle of scrolling horizontally.
+    ***        Set to false if the box is currently in the middle of scrolling vertically.
+    **/
+    bool _scrolling_horizontally;
 
     //! \brief The timer used for controlling option scrolling
     int32_t _scroll_time;


### PR DESCRIPTION
Hi,

This fixes an animation bug when scrolling through option menus.

The best way to see the issue is to scroll through options in the current menus.  The animation was not quite right.

I used the debug shop's buy menu and the video menu's resolution menu to test.

I would also recommend changing the code

```
void OptionBox::Update(uint32_t frame_time)
{
    // This will slow the animation down.
    frame_time = 1;
    ...
```

to more easily see how the menu is animating while testing.

The code change itself is very case based and kind of hard to read and follow.  I apologize about that.  Each type of menu, horizontal or vertical, has four cases: animating up, animation down, wrap-around top, and wrap-around bottom.

For the wrap-around cases, I chose to not animate and have the menu snap to the desired location.

Finally, I did not test any of the scrolling horizontal menu changes.  I am not aware of a scrolling horizontal menu in the game.  There probably is one somewhere and I just do not know about it.  I made the horizontal changes by mirroring the vertical menu changes.  Hopefully, they just work.  (This probably means the horizontal menu is broken. :D )

Let me know if you have any questions or comments.

Thanks.