### PR TITLE
Fixing the Cave Background Image

### DIFF
--- a/src/engine/video/gl/gl_render_target.cpp
+++ b/src/engine/video/gl/gl_render_target.cpp
@@ -68,7 +68,7 @@ RenderTarget::RenderTarget(unsigned width,
     BindTexture();
 
     // Initialize the texture.
-    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, _width, _height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+    glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _width, _height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
     if (glGetError() != GL_NO_ERROR) {
         PRINT_ERROR << "Failed to initialize the texture." << std::endl;
@@ -191,7 +191,7 @@ void RenderTarget::Resize(unsigned width,
 
     // Resize the texture.
     if (!errors) {
-        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGB, _width, _height, 0, GL_RGB, GL_UNSIGNED_BYTE, nullptr);
+        glTexImage2D(GL_TEXTURE_2D, 0, GL_RGBA, _width, _height, 0, GL_RGBA, GL_UNSIGNED_BYTE, nullptr);
 
         GLenum error = glGetError();
         if (error != GL_NO_ERROR) {

--- a/src/engine/video/video.cpp
+++ b/src/engine/video/video.cpp
@@ -268,10 +268,10 @@ bool VideoEngine::FinalizeInitialization()
     }
 
     // Prepare the screen for rendering.
-    glClearColor(::vt_video::Color::black[0],
-                 ::vt_video::Color::black[1],
-                 ::vt_video::Color::black[2],
-                 ::vt_video::Color::black[3]);
+    glClearColor(::vt_video::Color::clear[0],
+                 ::vt_video::Color::clear[1],
+                 ::vt_video::Color::clear[2],
+                 ::vt_video::Color::clear[3]);
     Clear();
 
     // Empty image used to draw colored rectangles.
@@ -616,9 +616,13 @@ void VideoEngine::DrawSecondaryRenderTarget()
 
     // Set up the video manager state.
     vt_video::VideoManager->PushState();
+
     vt_video::VideoManager->SetViewport(0.0f, 0.0f, width_render_target, height_render_target);
     vt_video::VideoManager->SetCoordSys(0.0f, width_render_target, height_render_target, 0.0f);
     vt_video::VideoManager->SetDrawFlags(vt_video::VIDEO_X_LEFT, vt_video::VIDEO_Y_TOP, vt_video::VIDEO_BLEND, 0);
+
+    VideoManager->EnableBlending();
+    glBlendFunc(GL_SRC_ALPHA, GL_ONE_MINUS_SRC_ALPHA);
 
     // Load the shader program.
     gl::ShaderProgram* shader_program = VideoManager->LoadShaderProgram(gl::shader_programs::Sprite);


### PR DESCRIPTION
Hi,

This is fix to address the cave background image not being displayed. (Issue #514)

The secondary render target was not being created with an alpha channel.

So, chronologically, the game would first draw the background image to backbuffer.  Then, the game would composite all the map images onto the secondary render target.  Next, the secondary render target would be drawn on top of the backbuffer.  However, without an alpha channel, the render target data would actually overwrite the entire backbuffer, stomping the background image in the process.

This should fix things up and allow the render target data to be properly blended into the backbuffer.

Let me know if there are any issues or if another problem comes up.

Thanks.