### PR TITLE
Fixing a memory leak in map mode.

### DIFF
--- a/src/common/dialogue.h
+++ b/src/common/dialogue.h
@@ -120,9 +120,9 @@ class Dialogue
 public:
     //! \param id The id number to represent the dialogue,
     //! which should be unique to other dialogue ids within the same game mode context
-    Dialogue(const std::string& dialogue_id);
+    explicit Dialogue(const std::string& dialogue_id);
 
-    ~Dialogue();
+    virtual ~Dialogue();
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.

--- a/src/modes/map/map_dialogue.h
+++ b/src/modes/map/map_dialogue.h
@@ -44,10 +44,11 @@ public:
     //! The event name is used to know whether the player has already seen a dialogue
     //! and display the dialogue bubble accordingly.
     //! If empty, the event is not stored.
-    SpriteDialogue(const std::string& dialogue_event_name);
+    explicit SpriteDialogue(const std::string& dialogue_event_name);
 
-    ~SpriteDialogue()
-    {}
+    virtual ~SpriteDialogue() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -311,7 +312,7 @@ public:
     MapDialogueOptions()
     {}
 
-    ~MapDialogueOptions()
+    virtual ~MapDialogueOptions() override
     {}
 
     /** \brief Adds a new option to the set of options

--- a/src/modes/map/map_events.h
+++ b/src/modes/map/map_events.h
@@ -204,8 +204,9 @@ public:
     **/
     DialogueEvent(const std::string& event_id, SpriteDialogue* dialogue);
 
-    ~DialogueEvent()
-    {}
+    virtual ~DialogueEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -247,8 +248,9 @@ public:
         _enable_sell_mode(true)
     {}
 
-    ~ShopEvent()
-    {}
+    virtual ~ShopEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -370,8 +372,10 @@ public:
     **/
     SoundEvent(const std::string& event_id, const std::string& sound_filename);
 
-    ~SoundEvent()
-    { _sound.Stop(); }
+    virtual ~SoundEvent() override
+    {
+        _sound.Stop();
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -414,7 +418,9 @@ public:
                        const std::string& script_filename,
                        const std::string& coming_from);
 
-    ~MapTransitionEvent() {};
+    virtual ~MapTransitionEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -456,10 +462,11 @@ class BattleEncounterEvent : public MapEvent
 public:
     /** \param event_id The ID of this event
     **/
-    BattleEncounterEvent(const std::string& event_id);
+    explicit BattleEncounterEvent(const std::string& event_id);
 
-    ~BattleEncounterEvent()
-    {}
+    virtual ~BattleEncounterEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -533,8 +540,9 @@ public:
     IfEvent(const std::string& event_id, const std::string& check_function,
             const std::string& on_true_event, const std::string& on_false_event);
 
-    ~IfEvent()
-    {}
+    virtual ~IfEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -585,8 +593,9 @@ public:
     ScriptedEvent(const std::string& event_id, const std::string& start_function,
                   const std::string& update_function);
 
-    ~ScriptedEvent()
-    {}
+    virtual ~ScriptedEvent() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -640,8 +649,9 @@ public:
     **/
     SpriteEvent(const std::string& event_id, EVENT_TYPE event_type, VirtualSprite* sprite);
 
-    ~SpriteEvent()
-    {}
+    virtual ~SpriteEvent() override
+    {
+    }
 
     VirtualSprite* GetSprite() const {
         return _sprite;
@@ -1044,9 +1054,10 @@ class TreasureEvent : public MapEvent
 public:
     /** \param event_id The ID of this event
     **/
-    TreasureEvent(const std::string& event_id);
+    explicit TreasureEvent(const std::string& event_id);
 
-    ~TreasureEvent() {
+    virtual ~TreasureEvent() override
+    {
         delete _treasure;
     }
 

--- a/src/modes/map/map_objects.cpp
+++ b/src/modes/map/map_objects.cpp
@@ -1270,7 +1270,7 @@ void ObjectSupervisor::DeleteObject(MapObject* object)
         return;
 
     for (uint32_t i = 0; i < _all_objects.size(); ++i) {
-        // We only set it to nullptr without removing its place in memory
+        // We only set it to null without removing its place in memory
         // to avoid breaking the vector key used as object id,
         // so that in: _all_objects[key]: key = object_id.
         if (_all_objects[i] == object) {

--- a/src/modes/map/map_objects.h
+++ b/src/modes/map/map_objects.h
@@ -97,8 +97,7 @@ class VirtualSprite;
 class MapObject
 {
 public:
-    MapObject(MapObjectDrawLayer layer);
-
+    explicit MapObject(MapObjectDrawLayer layer);
     virtual ~MapObject();
 
     /** \brief Updates the state of an object.
@@ -454,9 +453,8 @@ struct MapObject_Ptr_Less {
 class PhysicalObject : public MapObject
 {
 public:
-    PhysicalObject(MapObjectDrawLayer layer);
-
-    ~PhysicalObject();
+    explicit PhysicalObject(MapObjectDrawLayer layer);
+    virtual ~PhysicalObject() override;
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -555,8 +553,7 @@ class ParticleObject : public MapObject
 {
 public:
     ParticleObject(const std::string& filename, float x, float y, MapObjectDrawLayer layer);
-
-    ~ParticleObject();
+    virtual ~ParticleObject() override;
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -596,9 +593,9 @@ class SavePoint : public MapObject
 {
 public:
     SavePoint(float x, float y);
-
-    ~SavePoint()
-    {}
+    virtual ~SavePoint() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -641,9 +638,9 @@ class Halo : public MapObject
 public:
     //! \brief setup a halo on the map, using the given animation file.
     Halo(const std::string& filename, float x, float y, const vt_video::Color& color);
-
-    ~Halo()
-    {}
+    virtual ~Halo() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -659,7 +656,6 @@ public:
     //! \brief Draws the object to the screen, if it is visible.
     //! \note the actual image resources is handled by the main map object.
     void Draw();
-
 
 private:
     //! \brief A reference to the current map save animation.
@@ -684,8 +680,9 @@ public:
           float x, float y,
           const vt_video::Color &main_color, const vt_video::Color &secondary_color);
 
-    ~Light()
-    {}
+    virtual ~Light() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -760,8 +757,9 @@ public:
     **/
     SoundObject(const std::string& sound_filename, float x, float y, float strength);
 
-    ~SoundObject()
-    {}
+    virtual ~SoundObject() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.

--- a/src/modes/map/map_sprites.cpp
+++ b/src/modes/map/map_sprites.cpp
@@ -100,7 +100,8 @@ VirtualSprite::VirtualSprite(MapObjectDrawLayer layer) :
 }
 
 VirtualSprite::~VirtualSprite()
-{}
+{
+}
 
 void VirtualSprite::Update()
 {
@@ -638,7 +639,7 @@ MapSprite::MapSprite(MapObjectDrawLayer layer) :
 
 MapSprite::~MapSprite()
 {
-    if(_face_portrait)
+    if (_face_portrait)
         delete _face_portrait;
 }
 
@@ -1258,6 +1259,10 @@ EnemySprite::EnemySprite() :
     _object_type = ENEMY_TYPE;
     _moving = false;
     Reset();
+}
+
+EnemySprite::~EnemySprite()
+{
 }
 
 EnemySprite* EnemySprite::Create()

--- a/src/modes/map/map_sprites.h
+++ b/src/modes/map/map_sprites.h
@@ -58,16 +58,16 @@ const uint32_t STANDARD_ENEMY_DEAD_TIME = 5000;
 class VirtualSprite : public MapObject
 {
 public:
-    VirtualSprite(MapObjectDrawLayer layer);
-
-    ~VirtualSprite();
+    explicit VirtualSprite(MapObjectDrawLayer layer);
+    virtual ~VirtualSprite() override;
 
     //! \brief Updates the virtual object's position if it is moving, otherwise does nothing.
-    virtual void Update();
+    virtual void Update() override;
 
     //! \brief Does nothing since virtual sprites have no image to draw
-    virtual void Draw()
-    {}
+    virtual void Draw() override
+    {
+    }
 
     /** \note This method takes into account the current direction when setting the new direction
     *** in the case of diagonal movement. For example, if the sprite is currently facing north
@@ -245,9 +245,8 @@ protected:
 class MapSprite : public VirtualSprite
 {
 public:
-    MapSprite(MapObjectDrawLayer layer);
-
-    ~MapSprite();
+    explicit MapSprite(MapObjectDrawLayer layer);
+    virtual ~MapSprite() override;
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -562,6 +561,7 @@ private:
 public:
     //! \brief The default constructor
     EnemySprite();
+    virtual ~EnemySprite() override;
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.

--- a/src/modes/map/map_treasure.cpp
+++ b/src/modes/map/map_treasure.cpp
@@ -50,7 +50,8 @@ namespace private_map
 MapTreasure::MapTreasure() :
     _taken(false),
     _drunes(0)
-{}
+{
+}
 
 MapTreasure::~MapTreasure()
 {

--- a/src/modes/map/map_zones.h
+++ b/src/modes/map/map_zones.h
@@ -383,7 +383,7 @@ private:
     **/
     std::vector<EnemySprite*> _enemies;
 
-    /** \brief Contains all of the enemies that are owned by this class.  This objects must be cleaned up by this class.
+    /** \brief Contains all of the enemies that are owned by this class.  These objects must be cleaned up by this class.
     ***        This is a hack around a memory leak and should be addressed more formally in the future.
     **/
     std::vector<EnemySprite*> _enemies_owned;

--- a/src/modes/map/map_zones.h
+++ b/src/modes/map/map_zones.h
@@ -46,15 +46,15 @@ class ZoneSection
 public:
     ZoneSection(uint16_t left, uint16_t right, uint16_t top, uint16_t bottom) :
         left_col(left), right_col(right), top_row(top), bottom_row(bottom)
-    {}
+    {
+    }
 
     //! \brief Collision grid columns for the top and bottom section of the area
     uint16_t left_col, right_col;
 
     //! \brief Collision grid rows for the top and bottom section of the area
     uint16_t top_row, bottom_row;
-}; // class ZoneSection
-
+};
 
 /** ****************************************************************************
 *** \brief Represents a zone on a map that can take any shape
@@ -140,8 +140,16 @@ protected:
 
     //! \brief Tells whether a section is on screen and place the drawing cursor in that case.
     bool _ShouldDraw(const ZoneSection &section);
-}; // class MapZone
 
+private:
+    //
+    // The copy constructor and assignment operator are hidden by design
+    // to cause compilation errors when attempting to copy or assign this class.
+    //
+
+    MapZone(const MapZone& map_zone);
+    MapZone& operator=(const MapZone& map_zone);
+};
 
 /** ****************************************************************************
 *** \brief A zone which tracks when the map camera enters or exits
@@ -171,8 +179,9 @@ public:
     **/
     CameraZone(uint16_t left_col, uint16_t right_col, uint16_t top_row, uint16_t bottom_row);
 
-    virtual ~CameraZone()
-    {}
+    virtual ~CameraZone() override
+    {
+    }
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -181,7 +190,7 @@ public:
     static CameraZone* Create(uint16_t left_col, uint16_t right_col, uint16_t top_row, uint16_t bottom_row);
 
     //! \brief Updates the state of the zone by checking the current camera position
-    void Update();
+    virtual void Update() override;
 
     //! \brief Returns true if the sprite pointed to by the camera is located within the zone
     bool IsCameraInside() const {
@@ -204,7 +213,16 @@ protected:
 
     //! \brief Holds the previous value of _camera_inside
     bool _was_camera_inside;
-}; // class CameraZone : public MapZone
+
+private:
+    //
+    // The copy constructor and assignment operator are hidden by design
+    // to cause compilation errors when attempting to copy or assign this class.
+    //
+
+    CameraZone(const CameraZone& camera_zone);
+    CameraZone& operator=(const CameraZone& camera_zone);
+};
 
 
 /** ****************************************************************************
@@ -239,9 +257,7 @@ public:
     EnemyZone(uint16_t left_col, uint16_t right_col,
               uint16_t top_row, uint16_t bottom_row);
 
-    ~EnemyZone() {
-        if(_spawn_zone != nullptr) delete _spawn_zone;
-    }
+    virtual ~EnemyZone() override;
 
     //! \brief A C++ wrapper made to create a new object from scripting,
     //! without letting Lua handling the object life-cycle.
@@ -284,10 +300,10 @@ public:
     void EnemyDead();
 
     //! \brief Gradually spawns enemy sprites in the zone
-    void Update();
+    virtual void Update() override;
 
     //! \brief Draw the zone on screen for debugging purpose
-    void Draw();
+    virtual void Draw() override;
 
     //! \brief Returns true if this zone has seperate zones for roaming and spawning
     bool HasSeparateSpawnZone() const {
@@ -329,6 +345,14 @@ public:
     //@}
 
 private:
+    //
+    // The copy constructor and assignment operator are hidden by design
+    // to cause compilation errors when attempting to copy or assign this class.
+    //
+
+    EnemyZone(const EnemyZone& enemy_zone);
+    EnemyZone& operator=(const EnemyZone& enemy_zone);
+
     //! \brief Tells whether the zone is activated.
     bool _enabled;
 
@@ -357,8 +381,13 @@ private:
     /** \brief Contains all of the enemies that may exist in this zone.
     *** \note These sprites will be deleted by the map object manager, not the destructor of this class.
     **/
-    std::vector<EnemySprite *> _enemies;
-}; // class EnemyZone : public MapZone
+    std::vector<EnemySprite*> _enemies;
+
+    /** \brief Contains all of the enemies that are owned by this class.  This objects must be cleaned up by this class.
+    ***        This is a hack around a memory leak and should be addressed more formally in the future.
+    **/
+    std::vector<EnemySprite*> _enemies_owned;
+};
 
 } // namespace private_map
 


### PR DESCRIPTION
Hi,

This is a small fix for a memory leak in map mode.

The following memory allocations were not cleaned up:

```
for (uint8_t i = 1; i < enemy_number; ++i) {
         EnemySprite* copy = new EnemySprite(*enemy);
         copy->Reset();
         _enemies.push_back(copy);
}
```

This happens in the "EnemyZone::AddEnemy" function when extra copies of the enemy are requested by the second parameter.  Usually, this happens from the script files.

I fixed it by adding an extra vector to keep track of these extra allocations made by the zone class.  I do not particularly like this solution.  I think there is a better way to formally solve it.  However, in the short term, it at least fixes the memory leak.

Finally, I made some minor "override" keyword and "explicit" keyword changes to sections of the code base I searched through while trying to diagnose the leak.

Let me know if you have any questions or any issues come up.

Thanks.