### PR TITLE
Add Source Han Sans JP font's copyright.

### DIFF
--- a/data/fonts/OFL-1.1.txt
+++ b/data/fonts/OFL-1.1.txt
@@ -4,6 +4,9 @@ with Reserved Font Name "Linux Libertine" and "Biolinum".
 Copyright (c) 2011, wmk69 (wmk69@o2.pl),
 with Reserved Font Names 'Berenika Oblique'.
 
+Copyright (c) 2015, Adobe (https://github.com/adobe-fonts/source-han-sans),
+with Reserved Font Names 'Source Han Sans JP'.
+
 This Font Software is licensed under the SIL Open Font License, Version 1.1.
 This license is copied below, and is also available with a FAQ at:
 http://scripts.sil.org/OFL


### PR DESCRIPTION
Japanese font's copyright was missing.