### PR TITLE
Updating 'glTexParameter' to conform to the specification.

### DIFF
--- a/src/engine/video/gl/gl_render_target.cpp
+++ b/src/engine/video/gl/gl_render_target.cpp
@@ -78,8 +78,8 @@ RenderTarget::RenderTarget(unsigned width,
     // Initialize the texture filtering.
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     // Bind the texture to the framebuffer.
     glFramebufferTexture2D(GL_FRAMEBUFFER, GL_COLOR_ATTACHMENT0, GL_TEXTURE_2D, _texture, 0);

--- a/src/engine/video/texture_controller.cpp
+++ b/src/engine/video/texture_controller.cpp
@@ -199,8 +199,8 @@ GLuint TextureController::_CreateBlankGLTexture(int32_t width, int32_t height)
 
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MIN_FILTER, GL_LINEAR);
     glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_MAG_FILTER, GL_LINEAR);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP);
-    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_S, GL_CLAMP_TO_EDGE);
+    glTexParameteri(GL_TEXTURE_2D, GL_TEXTURE_WRAP_T, GL_CLAMP_TO_EDGE);
 
     return tex_id;
 }


### PR DESCRIPTION
Hi,

This is a minor change I discovered while reading OpenGL documentation while trying to fix the secondary render target map tile feature.

Here is a reference: https://www.khronos.org/opengles/sdk/docs/man/xhtml/glTexParameter.xml

Modern drivers must "do the right thing" for GL_CLAMP and assume GL_CLAMP_TO_EDGE was intended (or maybe it is actually defaulting to GL_REPEAT but we never render any geometry where we would actually notice a difference?).  Regardless, the code should probably be updated to use the correct value from the standard.

Thanks.