### PR TITLE
Initialize attack point when changing battle actor.

### DIFF
--- a/src/modes/battle/battle_utils.cpp
+++ b/src/modes/battle/battle_utils.cpp
@@ -449,6 +449,7 @@ bool BattleTarget::SelectNextActor(bool direction)
         // Set the new actor target and if required, ascertain the new target's validity. If the new target
         // must be valid and this new actor is not, the loop will continue and will try again with the next actor
         _actor_target = _party_target.at(new_target_index);
+        ReinitAttackPoint();
         if (IsValid())
             return true;
     }


### PR DESCRIPTION
BattleTarget::SelectNextActor() did not initialize attack point, so there was a bug that could't attack enemy who have fewer attack points.