### PR TITLE
Fixing a minor order of operations issue.

### DIFF
--- a/src/engine/video/gl/gl_vector.cpp
+++ b/src/engine/video/gl/gl_vector.cpp
@@ -76,8 +76,8 @@ Vector::Vector(float x, float y, float z, float w) :
 Vector& Vector::operator/=(float scale)
 {
     _x /= scale;
-    _z /= scale;
     _y /= scale;
+    _z /= scale;
     _w /= scale;
 
     return *this;


### PR DESCRIPTION
Hi,

This is a minor change.

The 'Y' and 'Z' were out of order in the vector class.  I updated it for clarity.

Thanks.