### PR TITLE
Fixed Error 1 error LNK2019 with VisualStudio builds.

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////////////
 //            Copyright (C) 2004-2011 by The Allacrost Project
-//            Copyright (C) 2012-2016 by Bertram (Valyria Tear)
+//            Copyright (C) 2012-2017 by Bertram (Valyria Tear)
 //                         All Rights Reserved
 //
 // This code is licensed under the GNU GPL version 2. It is free software
@@ -433,7 +433,7 @@ static void InitializeEngine() throw(Exception)
 }
 
 // Every great game begins with a single function :)
-int main(int argc, const char *argv[])
+int main(int argc, char *argv[])
 {
 #   if defined (_MSC_VER) && defined(_DEBUG)
         // Enable the debug heap manager for Visual Studio debug builds.

--- a/src/main_options.cpp
+++ b/src/main_options.cpp
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //            Copyright (C) 2004-2011 by The Allacrost Project
-//            Copyright (C) 2012-2016 by Bertram (Valyria Tear)
+//            Copyright (C) 2012-2017 by Bertram (Valyria Tear)
 //                         All Rights Reserved
 //
 // This code is licensed under the GNU GPL version 2. It is free software
@@ -53,7 +53,7 @@ using namespace vt_utils;
 namespace vt_main
 {
 
-bool ParseProgramOptions(int32_t &return_code, int32_t argc, const char **argv)
+bool ParseProgramOptions(int32_t &return_code, int32_t argc, char *argv[])
 {
     // Convert the argument list to a vector of strings for convenience
     std::vector<std::string> options(argv, argv + argc);
@@ -102,7 +102,7 @@ bool ParseProgramOptions(int32_t &return_code, int32_t argc, const char **argv)
     }
 
     return true;
-} // bool ParseProgramOptions(int32_t &return_code, int32_t argc, char **argv)
+} // bool ParseProgramOptions(int32_t &return_code, int32_t argc, char *argv[])
 
 bool ParseSecondaryOptions(const std::string &vars, std::vector<std::string>& options)
 {

--- a/src/main_options.h
+++ b/src/main_options.h
@@ -1,6 +1,6 @@
 ///////////////////////////////////////////////////////////////////////////////
 //            Copyright (C) 2004-2011 by The Allacrost Project
-//            Copyright (C) 2012-2016 by Bertram (Valyria Tear)
+//            Copyright (C) 2012-2017 by Bertram (Valyria Tear)
 //                         All Rights Reserved
 //
 // This code is licensed under the GNU GPL version 2. It is free software
@@ -30,7 +30,7 @@ namespace vt_main {
 *** \param argv A pointer to the list of arguments
 *** \return False if the program should exit with a return code, or true if it should continue
 **/
-bool ParseProgramOptions(int32_t& return_code, int32_t argc, const char **argv);
+bool ParseProgramOptions(int32_t& return_code, int32_t argc, char *argv[]);
 
 /** \brief Parses a secondary list of options provided to a primary program option
 *** \param vars The list of secondary options in single string format


### PR DESCRIPTION
Changed argument signature for main() and ParseProgramOptions() to resolve conflict with SDL_main.h that redefines main.

This fixes #556.