### PR TITLE
Eliminate "Yes" / "No" + improvements to option strings

### DIFF
--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -489,7 +489,7 @@ void GameOptionsMenuHandler::_SetupGameOptions()
     _game_options_menu.AddOption(text, this, nullptr, nullptr, nullptr,
                                  &GameOptionsMenuHandler::_OnDialogueSpeedLeft,
                                  &GameOptionsMenuHandler::_OnDialogueSpeedRight);
-    text = MakeUnicodeString(VTranslate("Battle target cursor memory: %s", (SystemManager->GetBattleTargetMemory() ? Translate("Yes") : Translate("No"))));
+    text = MakeUnicodeString(VTranslate("Remember battle target: %s", (SystemManager->GetBattleTargetMemory() ? Translate("Enabled") : Translate("Disabled"))));
     _game_options_menu.AddOption(text, this, &GameOptionsMenuHandler::_OnBattleTargetCursorMemoryConfirm);
 }
 
@@ -811,7 +811,7 @@ void GameOptionsMenuHandler::_RefreshGameOptions()
     text = MakeUnicodeString(VTranslate("Dialogue text speed: %i", static_cast<int32_t>(SystemManager->GetMessageSpeed())));
     _game_options_menu.SetOptionText(1, text);
 
-    text = MakeUnicodeString(VTranslate("Battle target cursor memory: %s", (SystemManager->GetBattleTargetMemory() ? Translate("Yes") : Translate("No"))));
+    text = MakeUnicodeString(VTranslate("Remember battle target: %s", (SystemManager->GetBattleTargetMemory() ? Translate("Enabled") : Translate("Disabled"))));
     _game_options_menu.SetOptionText(2, text);
 }
 
@@ -832,21 +832,17 @@ void GameOptionsMenuHandler::_RefreshKeySettings()
 void GameOptionsMenuHandler::_RefreshJoySettings()
 {
     int32_t i = 0;
-    if(InputManager->GetJoysticksEnabled())
-        _joy_settings_menu.SetOptionText(i++, UTranslate("Input enabled: ") + MakeUnicodeString("<r>") +  UTranslate("Yes"));
-    else
-        _joy_settings_menu.SetOptionText(i++, UTranslate("Input enabled: ") + MakeUnicodeString("<r>") +  UTranslate("No"));
-
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Input") + MakeUnicodeString("<r>") +  UTranslate(InputManager->GetJoysticksEnabled() ? "Enabled" : "Disabled"));
     _joy_settings_menu.SetOptionText(i++, UTranslate("X Axis") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetXAxisJoy())));
     _joy_settings_menu.SetOptionText(i++, UTranslate("Y Axis") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetYAxisJoy())));
     _joy_settings_menu.SetOptionText(i++, UTranslate("Threshold") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetThresholdJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Confirm: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetConfirmJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Cancel: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetCancelJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Menu: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetMenuJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Map: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetMinimapJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Pause: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetPauseJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Help: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetHelpJoy())));
-    _joy_settings_menu.SetOptionText(i++, UTranslate("Quit: Button") + MakeUnicodeString("<r>" + NumberToString(InputManager->GetQuitJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Confirm") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetConfirmJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Cancel") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetCancelJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Menu") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetMenuJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Map") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetMinimapJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Pause") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetPauseJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Help") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetHelpJoy())));
+    _joy_settings_menu.SetOptionText(i++, UTranslate("Quit") + MakeUnicodeString("<r>" + VTranslate("Button %d", InputManager->GetQuitJoy())));
 }
 
 void GameOptionsMenuHandler::_OnVideoOptions()
@@ -1222,7 +1218,7 @@ void GameOptionsMenuHandler::_UpdateExplanationText()
             _explanation_window.SetText(UTranslate("Permits to set up the dialogue text scrolling speed (in character per seconds)..."));
             break;
         case 2:
-            _explanation_window.SetText(UTranslate("Sets whether the battle target should be kept in memory between two actions for a given character."));
+            _explanation_window.SetText(UTranslate("Sets whether the characters will remember their previous action in battle."));
             break;
         default:
             _explanation_window.Hide();
@@ -1404,7 +1400,7 @@ bool GameOptionsMenuHandler::_SaveSettingsFile(const std::string& filename)
                << vt_gui::DEFAULT_MESSAGE_SPEED << ")";
     settings_lua.WriteComment(speed_text.str());
     settings_lua.WriteInt("message_speed", SystemManager->GetMessageSpeed());
-    settings_lua.WriteComment("Whether the latest battle target should be kept in memory between two actions for each characters. (Default: 'true')");
+    settings_lua.WriteComment("Sets whether each character will remember their previous action in battle. (Default: 'true')");
     settings_lua.WriteBool("battle_target_cursor_memory", SystemManager->GetBattleTargetMemory());
     settings_lua.EndTable(); // game_options
 

--- a/src/modes/battle/battle_finish.cpp
+++ b/src/modes/battle/battle_finish.cpp
@@ -157,8 +157,8 @@ FinishDefeatAssistant::FinishDefeatAssistant(FINISH_STATE &state) :
     _confirm_options.SetSelectMode(VIDEO_SELECT_SINGLE);
     _confirm_options.SetHorizontalWrapMode(VIDEO_WRAP_MODE_STRAIGHT);
     _confirm_options.SetCursorOffset(-60.0f, -25.0f);
-    _confirm_options.AddOption(UTranslate("Yes"));
-    _confirm_options.AddOption(UTranslate("No"));
+    _confirm_options.AddOption(UTranslate("OK"));
+    _confirm_options.AddOption(UTranslate("Cancel"));
     _confirm_options.SetSelection(0);
 
     _tooltip.SetOwner(&_tooltip_window);
@@ -195,7 +195,7 @@ void FinishDefeatAssistant::Update()
                 AudioManager->PlaySound("data/sounds/cancel.wav");
             } else {
                 _state = FINISH_DEFEAT_CONFIRM;
-                // Set default confirm option to "No"
+                // Set default confirm option to "Cancel"
                 if(_options.GetSelection() == (int32_t)DEFEAT_OPTION_END)
                     _confirm_options.SetSelection(1);
                 else
@@ -219,12 +219,12 @@ void FinishDefeatAssistant::Update()
         _confirm_options.Update();
         if(InputManager->ConfirmPress()) {
             switch(_confirm_options.GetSelection()) {
-            case 0: // "Yes"
+            case 0: // "OK"
                 _state = FINISH_END;
                 _options_window.Hide();
                 _tooltip_window.Hide();
                 break;
-            case 1: // "No"
+            case 1: // "Cancel"
                 _state = FINISH_DEFEAT_SELECT;
                 _SetTooltipText();
                 break;


### PR DESCRIPTION
- Replaced yes/no in battle result screen with ok/cancel
- Replaced yes/no in options with enabled/disabled
- In the Joystick options, shifted "Button" to the options' values
- Less technical text for "Battle target cursor memory"

Motivation for this change: Some languages don't have words for yes/no.