### PR TITLE
Fixed diverse text truncation & alignment issues

### DIFF
--- a/data/credits/episode1_credits.lua
+++ b/data/credits/episode1_credits.lua
@@ -175,9 +175,9 @@ function DrawPostEffects()
 
     header_color:SetAlpha(1.0 * text_alpha);
     text_color:SetAlpha(0.9 * text_alpha);
-    VideoManager:Move(870.0, 600.0);
+    VideoManager:Move(850.0, 600.0);
     credit_map[credit_id].header:Draw(header_color);
-    VideoManager:Move(870.0, 648.0);
+    VideoManager:Move(850.0, 648.0);
     credit_map[credit_id].text:Draw(text_color);
 
     -- Custom images in honor of those who helped :)

--- a/src/common/gui/textbox.cpp
+++ b/src/common/gui/textbox.cpp
@@ -333,7 +333,7 @@ void TextBox::_ReformatText()
     if (_text_xalign == VIDEO_X_LEFT) {
         _text_xpos = left;
     } else if (_text_xalign == VIDEO_X_CENTER) {
-        _text_xpos = (left + right) * 0.5f;
+        _text_xpos = (left + right - _text_image.GetWidth()) * 0.5f;
     } else { // (_text_xalign == VIDEO_X_RIGHT)
         _text_xpos = right;
     }

--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -140,7 +140,7 @@ GameOptionsMenuHandler::GameOptionsMenuHandler(vt_mode_manager::GameMode* parent
     _joy_setting_function(nullptr),
     _joy_axis_setting_function(nullptr),
     _message_window(ustring(), -1.0f, -1.0f, 410.0f, 133.0f),
-    _explanation_window(ustring(), -1.0f, 650.0f, 510.0f, 100.0f),
+    _explanation_window(ustring(), -1.0f, 650.0f, VideoManager->GetScreenWidth() - 100.f, 100.0f),
     _parent_mode(parent_mode)
 {
     // Create the option window used as background

--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -403,7 +403,7 @@ void GameOptionsMenuHandler::_SetupVideoOptionsMenu()
 {
     _video_options_menu.ClearOptions();
     _video_options_menu.SetPosition(512.0f, 338.0f);
-    _video_options_menu.SetDimensions(300.0f, 400.0f, 1, 6, 1, 6);
+    _video_options_menu.SetDimensions(350.0f, 400.0f, 1, 6, 1, 6);
     _video_options_menu.SetTextStyle(TextStyle("title22"));
     _video_options_menu.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
     _video_options_menu.SetOptionAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
@@ -456,7 +456,7 @@ void GameOptionsMenuHandler::_SetupGameOptions()
 {
     _game_options_menu.ClearOptions();
     _game_options_menu.SetPosition(512.0f, 338.0f);
-    _game_options_menu.SetDimensions(300.0f, 200.0f, 1, 3, 1, 3);
+    _game_options_menu.SetDimensions(350.0f, 200.0f, 1, 3, 1, 3);
     _game_options_menu.SetTextStyle(TextStyle("title22"));
     _game_options_menu.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
     _game_options_menu.SetOptionAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
@@ -511,7 +511,7 @@ void GameOptionsMenuHandler::_SetupKeySettingsMenu()
 {
     _key_settings_menu.ClearOptions();
     _key_settings_menu.SetPosition(512.0f, 338.0f);
-    _key_settings_menu.SetDimensions(250.0f, 500.0f, 1, 10, 1, 10);
+    _key_settings_menu.SetDimensions(300.0f, 500.0f, 1, 10, 1, 10);
     _key_settings_menu.SetTextStyle(TextStyle("title20"));
     _key_settings_menu.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
     _key_settings_menu.SetOptionAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);

--- a/src/modes/battle/battle_finish.cpp
+++ b/src/modes/battle/battle_finish.cpp
@@ -327,10 +327,10 @@ FinishVictoryAssistant::FinishVictoryAssistant(FINISH_STATE& state) :
     _spoils_window.Show();
 
     _header_growth.SetOwner(&_header_window);
-    _header_growth.SetPosition(TOP_WINDOW_WIDTH / 2 - 50.0f, 15.0f);
-    _header_growth.SetDimensions(400.0f, 40.0f);
+    _header_growth.SetPosition(SPOILS_WINDOW_XPOS - SPOILS_WINDOW_WIDTH + 50.0f, 15.0f);
+    _header_growth.SetDimensions(SPOILS_WINDOW_WIDTH - 100.0f, 40.0f);
     _header_growth.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
-    _header_growth.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+    _header_growth.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_TOP);
     _header_growth.SetDisplaySpeed(SystemManager->GetMessageSpeed());
     _header_growth.SetTextStyle(TextStyle("text20", Color::white));
     _header_growth.SetDisplayMode(VIDEO_TEXT_INSTANT);
@@ -360,10 +360,10 @@ FinishVictoryAssistant::FinishVictoryAssistant(FINISH_STATE& state) :
     }
 
     _object_header_text.SetOwner(&_spoils_window);
-    _object_header_text.SetPosition(SPOILS_WINDOW_WIDTH / 2 - 50.0f, 15.0f);
-    _object_header_text.SetDimensions(350.0f, 40.0f);
+    _object_header_text.SetPosition(SPOILS_WINDOW_XPOS - SPOILS_WINDOW_WIDTH + 50.0f, 15.0f);
+    _object_header_text.SetDimensions(SPOILS_WINDOW_WIDTH - 100.0f, 40.0f);
     _object_header_text.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
-    _object_header_text.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+    _object_header_text.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_TOP);
     _object_header_text.SetDisplaySpeed(SystemManager->GetMessageSpeed());
     _object_header_text.SetTextStyle(TextStyle("title20", Color::white));
     _object_header_text.SetDisplayMode(VIDEO_TEXT_INSTANT);
@@ -896,10 +896,10 @@ FinishSupervisor::FinishSupervisor() :
     _defeat_assistant(_state),
     _victory_assistant(_state)
 {
-    _outcome_text.SetPosition(400.0f, 48.0f);
+    _outcome_text.SetPosition(TOP_WINDOW_XPOS - TOP_WINDOW_WIDTH / 2.0f, 48.0f);
+    _outcome_text.SetDimensions(TOP_WINDOW_WIDTH, 50.0f);
     _outcome_text.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
-    _outcome_text.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
-    _outcome_text.SetDimensions(400.0f, 50.0f);
+    _outcome_text.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_TOP);
     _outcome_text.SetDisplaySpeed(SystemManager->GetMessageSpeed());
     _outcome_text.SetTextStyle(TextStyle("text24", Color::white));
     _outcome_text.SetDisplayMode(VIDEO_TEXT_INSTANT);

--- a/src/modes/menu/menu.cpp
+++ b/src/modes/menu/menu.cpp
@@ -361,7 +361,7 @@ void InventoryState::Reset()
 {
     // Setup the option box
     SetupOptionBoxCommonSettings(&_options);
-    _options.SetDimensions(555.0f, 50.0f, INV_OPTIONS_SIZE, 1, INV_OPTIONS_SIZE, 1);
+    _options.SetDimensions(745.0f, 50.0f, INV_OPTIONS_SIZE, 1, INV_OPTIONS_SIZE, 1);
 
     // Generate the strings
     std::vector<ustring> options;
@@ -847,11 +847,11 @@ MenuMode::MenuMode() :
     _spirit_description.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
     _spirit_description.SetDisplayText(UTranslate("This item is an elemental spirit and can be associated with equipment."));
 
-    _help_information.SetPosition(250, 570);
-    _help_information.SetDimensions(500, 100);
+    _help_information.SetPosition(150, 570);
+    _help_information.SetDimensions(700, 100);
     _help_information.SetTextStyle(TextStyle("text20"));
     _help_information.SetDisplayMode(VIDEO_TEXT_INSTANT);
-    _help_information.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+    _help_information.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_TOP);
 
     _atk_icon = media.GetStatusIcon(GLOBAL_STATUS_PHYS_ATK, GLOBAL_INTENSITY_NEUTRAL);
     _matk_icon = media.GetStatusIcon(GLOBAL_STATUS_MAG_ATK, GLOBAL_INTENSITY_NEUTRAL);
@@ -1306,7 +1306,8 @@ void MenuMode::DrawEquipmentInfo()
     _mag_header.Draw();
 
     VideoManager->SetDrawFlags(VIDEO_X_RIGHT, 0);
-    VideoManager->MoveRelative(110.0f, -30.0f);
+    const float header_width = std::max(_phys_header.GetWidth(), _mag_header.GetWidth()) + 16.0f;
+    VideoManager->MoveRelative(header_width, -30.0f);
     _phys_stat.Draw();
     VideoManager->MoveRelative(0.0f, 30.0f);
     _mag_stat.Draw();

--- a/src/modes/menu/menu_views.cpp
+++ b/src/modes/menu/menu_views.cpp
@@ -1083,12 +1083,14 @@ void PartyWindow::Draw()
     VideoManager->Move(440.0f, 130.0f);
     _full_portraits[_char_select.GetSelection()].Draw();
 
-    VideoManager->Move(660.0f, 130.0f);
+    const float status_x = _x_position + _width - 48.0f
+          - _character_status_text.GetWidth() - _character_status_numbers.GetWidth() - _character_status_icons.GetWidth();
+    VideoManager->Move(status_x, 140.0f);
     _character_status_text.Draw();
-    VideoManager->MoveRelative(200.0f, 0.0f);
-    _character_status_numbers.Draw();
-    VideoManager->MoveRelative(-25.0f, 67.0f);
+    VideoManager->MoveRelative(_character_status_text.GetWidth() + 8.0f, 67.0f);
     _character_status_icons.Draw();
+    VideoManager->MoveRelative(_character_status_icons.GetWidth() + 8.0f, -67.0f);
+    _character_status_numbers.Draw();
 
     if (GetActiveState() != FORM_ACTIVE_NONE) {
         VideoManager->Move(450.0f, 500.0f);

--- a/src/modes/mode_help_window.cpp
+++ b/src/modes/mode_help_window.cpp
@@ -38,7 +38,7 @@ namespace vt_mode_manager
 HelpWindow::HelpWindow() :
     _active(false)
 {
-    _window.Create(880.0f, 640.0f);
+    _window.Create(900.0f, 640.0f);
     _window.SetPosition(512.0f, 384.0f);
     _window.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
 

--- a/src/modes/pause.cpp
+++ b/src/modes/pause.cpp
@@ -74,7 +74,7 @@ PauseMode::PauseMode(bool quit_state, bool pause_audio) :
 
     // Initialize the quit options box
     _quit_options.SetPosition(512.0f, 384.0f);
-    _quit_options.SetDimensions(220.0f, 300.0f, 1, 4, 1, 4);
+    _quit_options.SetDimensions(420.0f, 300.0f, 1, 4, 1, 4);
     _quit_options.SetTextStyle(TextStyle("title24", Color::white, VIDEO_TEXT_SHADOW_BLACK));
 
     _quit_options.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);

--- a/src/modes/save/save_mode.cpp
+++ b/src/modes/save/save_mode.cpp
@@ -75,11 +75,15 @@ SaveMode::SaveMode(bool save_mode, uint32_t x_position, uint32_t y_position) :
     _title_window.SetPosition(212.0f, 88.0f);
     _title_window.Show();
 
+    const float centered_text_xpos = _window.GetXPosition() + 50.0f;
+    const float centered_text_width = _window.GetWidth() - 100.f;
+
     // Initialize the save successful message box
-    _title_textbox.SetPosition(552.0f, 103.0f);
-    _title_textbox.SetDimensions(200.0f, 50.0f);
+    _title_textbox.SetPosition(centered_text_xpos, 103.0f);
+    _title_textbox.SetDimensions(centered_text_width, 50.0f);
     _title_textbox.SetTextStyle(TextStyle("title22"));
-    _title_textbox.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
+    _title_textbox.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _title_textbox.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_BOTTOM);
     if(_save_mode)
         _title_textbox.SetDisplayText(UTranslate("Save Game"));
     else
@@ -111,7 +115,7 @@ SaveMode::SaveMode(bool save_mode, uint32_t x_position, uint32_t y_position) :
 
     // Initialize the confirmation option box
     _confirm_save_optionbox.SetPosition(512.0f, 384.0f);
-    _confirm_save_optionbox.SetDimensions(280.0f, 200.0f, 1, 2, 1, 2);
+    _confirm_save_optionbox.SetDimensions(centered_text_width, 200.0f, 1, 2, 1, 2);
     _confirm_save_optionbox.SetTextStyle(TextStyle("title22"));
 
     _confirm_save_optionbox.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
@@ -125,7 +129,7 @@ SaveMode::SaveMode(bool save_mode, uint32_t x_position, uint32_t y_position) :
 
     // Initialize the auto-save option box
     _load_auto_save_optionbox.SetPosition(512.0f, 384.0f);
-    _load_auto_save_optionbox.SetDimensions(250.0f, 200.0f, 1, 3, 1, 3);
+    _load_auto_save_optionbox.SetDimensions(centered_text_width, 200.0f, 1, 3, 1, 3);
     _load_auto_save_optionbox.SetTextStyle(TextStyle("title22"));
 
     _load_auto_save_optionbox.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
@@ -139,23 +143,26 @@ SaveMode::SaveMode(bool save_mode, uint32_t x_position, uint32_t y_position) :
     _load_auto_save_optionbox.SetSelection(0);
 
     // Initialize the save successful message box
-    _save_success_message.SetPosition(552.0f, 314.0f);
-    _save_success_message.SetDimensions(250.0f, 100.0f);
+    _save_success_message.SetPosition(centered_text_xpos, 314.0f);
+    _save_success_message.SetDimensions(centered_text_width, 100.0f);
     _save_success_message.SetTextStyle(TextStyle("title22"));
-    _save_success_message.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
+    _save_success_message.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _save_success_message.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_BOTTOM);
     _save_success_message.SetDisplayText(UTranslate("Save successful!"));
 
     // Initialize the save failure message box
-    _save_failure_message.SetPosition(512.0f, 384.0f);
-    _save_failure_message.SetDimensions(250.0f, 100.0f);
+    _save_failure_message.SetPosition(centered_text_xpos, 314.0f);
+    _save_failure_message.SetDimensions(centered_text_width, 100.0f);
     _save_failure_message.SetTextStyle(TextStyle("title22"));
-    _save_failure_message.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
+    _save_failure_message.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _save_failure_message.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_BOTTOM);
     _save_failure_message.SetDisplayText(UTranslate("Unable to save game!\nSave FAILED!"));
 
-    _no_valid_saves_message.SetPosition(512.0f, 384.0f);
-    _no_valid_saves_message.SetDimensions(250.0f, 100.0f);
+    _no_valid_saves_message.SetPosition(centered_text_xpos, 314.0f);
+    _no_valid_saves_message.SetDimensions(centered_text_width, 100.0f);
     _no_valid_saves_message.SetTextStyle(TextStyle("title22"));
-    _no_valid_saves_message.SetAlignment(VIDEO_X_CENTER, VIDEO_Y_CENTER);
+    _no_valid_saves_message.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_CENTER);
+    _no_valid_saves_message.SetTextAlignment(VIDEO_X_CENTER, VIDEO_Y_BOTTOM);
     _no_valid_saves_message.SetDisplayText(UTranslate("No valid saves found!"));
 
     // Initialize the save preview text boxes

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -671,9 +671,9 @@ void ShopObjectViewer::_SetDescriptionText()
         _description_text.SetOwner(ShopMode::CurrentInstance()->GetBottomWindow());
         // For key items, draw position is a little higher than other cases to center it in the blank area
         if(_selected_object && _selected_object->GetObject()->IsKeyItem()) {
-            _description_text.SetPosition(102.0f, 64.0f);
+            _description_text.SetPosition(102.0f, 104.0f);
         } else {
-            _description_text.SetPosition(102.0f, 84.0f);
+            _description_text.SetPosition(102.0f, 124.0f);
         }
         _description_text.SetDimensions(675.0f, 50.0f);
     }
@@ -797,8 +797,14 @@ void ShopObjectViewer::_DrawItem()
     VideoManager->SetDrawFlags(VIDEO_X_LEFT, VIDEO_Y_CENTER, 0);
 
     VideoManager->MoveRelative(80.0f, -15.0f);
+    _target_type_header.Draw();
+    float move_offset = _target_type_header.GetWidth() + 5.0f;
+    VideoManager->MoveRelative(move_offset, 0.0f);
+    _target_type_text[_target_type_index].Draw();
+
+    VideoManager->MoveRelative(-move_offset, 28.0f);
     _field_use_header.Draw();
-    float move_offset = _field_use_header.GetWidth() + 5.0f; // 5.0f is a small buffer space between text and graphic
+    move_offset = _field_use_header.GetWidth() + 5.0f; // 5.0f is a small buffer space between text and graphic
     VideoManager->MoveRelative(move_offset, 0.0f);
     if(_map_usable) {
         _check_icon->Draw();
@@ -815,12 +821,6 @@ void ShopObjectViewer::_DrawItem()
     } else {
         _x_icon->Draw();
     }
-
-    VideoManager->MoveRelative(175.0f - move_offset, 0.0f);
-    _target_type_header.Draw();
-    move_offset = _target_type_header.GetWidth() + 5.0f;
-    VideoManager->MoveRelative(move_offset, 0.0f);
-    _target_type_text[_target_type_index].Draw();
 
     _description_text.Draw();
     _hint_text.Draw();
@@ -848,7 +848,8 @@ void ShopObjectViewer::_DrawEquipment()
     _mag_header.Draw();
 
     VideoManager->SetDrawFlags(VIDEO_X_RIGHT, 0);
-    VideoManager->MoveRelative(110.0f, -30.0f);
+    const float header_width = std::max(_phys_header.GetWidth(), _mag_header.GetWidth()) + 16.0f;
+    VideoManager->MoveRelative(header_width, -30.0f);
     _phys_rating.Draw();
     VideoManager->MoveRelative(0.0f, 30.0f);
     _mag_rating.Draw();
@@ -1003,12 +1004,12 @@ ShopMode::ShopMode(const std::string& shop_id) :
     _top_window.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
     _top_window.Show();
 
-    _middle_window.Create(800.0f, 400.0f, VIDEO_MENU_EDGE_ALL, VIDEO_MENU_EDGE_TOP | VIDEO_MENU_EDGE_BOTTOM);
+    _middle_window.Create(800.0f, 380.0f, VIDEO_MENU_EDGE_ALL, VIDEO_MENU_EDGE_TOP | VIDEO_MENU_EDGE_BOTTOM);
     _middle_window.SetPosition(112.0f, 164.0f);
     _middle_window.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
     _middle_window.Show();
 
-    _bottom_window.Create(800.0f, 140.0f, ~VIDEO_MENU_EDGE_TOP);
+    _bottom_window.Create(800.0f, 160.0f, ~VIDEO_MENU_EDGE_TOP);
     _bottom_window.SetPosition(112.0f, 544.0f);
     _bottom_window.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
     _bottom_window.Show();

--- a/src/modes/shop/shop_root.cpp
+++ b/src/modes/shop/shop_root.cpp
@@ -124,9 +124,10 @@ void RootInterface::Reinitialize()
     gray_star = star;
     gray_star.SetGrayscale(true);
 
+
     // Finally, construct the composite images with the correct star rating
-    _buy_price_rating.SetDimensions(200.0f, 30.0f);
-    _sell_price_rating.SetDimensions(200.0f, 30.0f);
+    _buy_price_rating.SetDimensions(160.0f + star.GetWidth(), 30.0f);
+    _sell_price_rating.SetDimensions(160.0f + star.GetWidth(), 30.0f);
 
     float offset = 0.0f;
     for(uint8_t count = 5; count > 0; count--) {
@@ -166,16 +167,17 @@ void RootInterface::Draw()
     VideoManager->Move(512.0f, 188.0f);
     _shop_name.Draw();
 
+    const float rating_offset = (512.0f - _buy_price_rating.GetWidth()) / 2.0f;
     // Middle window: below the shop name draw the pricing text and rating image
-    VideoManager->MoveRelative(-140.0f, 60.0f);
-    _buy_price_text.Draw();
-    VideoManager->MoveRelative(280.0f, 0.0f);
-    _sell_price_text.Draw();
-
-    VideoManager->MoveRelative(-280.0f, 40.0f);
+    VideoManager->MoveRelative(-rating_offset, 100.0f);
     _buy_price_rating.Draw();
-    VideoManager->MoveRelative(280.0f, 0.0f);
+    VideoManager->MoveRelative(0.0f, -40.0f);
+    _buy_price_text.Draw();
+
+    VideoManager->MoveRelative(2.0f * rating_offset, 40.0f);
     _sell_price_rating.Draw();
+    VideoManager->MoveRelative(0.0f, -40.0f);
+    _sell_price_text.Draw();
 
     // Bottom window: draw the greeting text
     _greeting_text.Draw();


### PR DESCRIPTION
Fixed general string alignment and truncation issues, and truncation issues for translated strings.

- Diverse truncation and alignment issues in in-game menu.

- Bottom shop window:
    - Made the window a bit taller to fit the icons
    - Now we have enough vertical space to move the Target description to its own line
    - Physical/Magical values now calculate their x-position from the headers.
- Fixed horizontal text center alignment in the gui toolkit, load/save menu, battle outcome screen and  shop root.
- Increased width for Episode I credits, help window, pause menu, options window and Options explanation window.