### PR TITLE
Support for ngettext and comments for translators in C++

### DIFF
--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -64,14 +64,11 @@ MACRO(VALYRIATEAR_GETTEXT_UPDATE_PO _potFile _languages)
 
    ADD_CUSTOM_TARGET(
       update-pot
-      # Standard keywords
-      COMMAND xgettext -c/ -C --files-from=translatable-files --directory=. --output=${_potFile} -d valyriatear --keyword=_ --keyword=N_ --keyword=Translate --keyword=UTranslate --from-code=UTF-8
-      # Contextual translation keywords
-      COMMAND xgettext -c/ -C --files-from=translatable-files -j --directory=. --output=${_potFile} -d valyriatear --keyword=CTranslate --keyword=CUTranslate --from-code=UTF-8
-      # C-formatted translation keywords
-      COMMAND xgettext -c/ -C --files-from=translatable-files -j --directory=. --output=${_potFile} -d valyriatear --keyword=VTranslate:1 --from-code=UTF-8
+      # Strings from C++
+      COMMAND xgettext -C --files-from=translatable-files --directory=. --output=${_potFile} -d valyriatear --keyword=_ --keyword=N_ --keyword=Translate --keyword=UTranslate --keyword=CTranslate --keyword=CUTranslate --keyword=VTranslate:1 --keyword=NVTranslate:1,2 --add-comments --from-code=UTF-8
+      # Strings from Lua
       COMMAND bash create_map_names_translatable_strings.sh
-      COMMAND xgettext -c/ -C --directory=. -j --output=${_potFile} -d valyriatear --keyword=Translate --from-code=UTF-8  map_names_tr.lua
+      COMMAND xgettext -C --directory=. -j --output=${_potFile} -d valyriatear --keyword=Translate --add-comments --from-code=UTF-8  map_names_tr.lua
 
       # The pot file is ready - We can remove the temp files
       COMMAND rm -f translatable-files

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -131,6 +131,19 @@ std::string VTranslate(const std::string& text, uint32_t arg1, uint32_t arg2)
 std::string VTranslate(const std::string& text, const std::string& arg1, const std::string& arg2)
 { return _VTranslate(text, arg1.c_str(), arg2.c_str()); }
 
+std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long  number, ...) {
+    // Don't translate an empty string as it will return the PO meta data.
+    if (singular.empty() || plural.empty())
+         return std::string();
+
+    va_list va;
+    va_start(va, number);
+    std::string translation = ngettext(singular.c_str(), plural.c_str(), number);
+    translation = strprintf(translation.c_str(), number, va);
+    va_end(va);
+    return translation;
+}
+
 
 // -----------------------------------------------------------------------------
 // SystemTimer Class
@@ -528,7 +541,7 @@ void SystemEngine::AddAutoTimer(SystemTimer *timer)
         return;
     }
 
-// 	pair<set<SystemTimer*>::iterator, bool> return_value;
+//     pair<set<SystemTimer*>::iterator, bool> return_value;
     if(_auto_system_timers.insert(timer).second == false) {
         IF_PRINT_WARNING(SYSTEM_DEBUG) << "timer already existed in auto system timer container" << std::endl;
     }

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -131,19 +131,24 @@ std::string VTranslate(const std::string& text, uint32_t arg1, uint32_t arg2)
 std::string VTranslate(const std::string& text, const std::string& arg1, const std::string& arg2)
 { return _VTranslate(text, arg1.c_str(), arg2.c_str()); }
 
-std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long  number, ...) {
+std::string NVTranslate(const std::string &singular, const std::string &plural, const unsigned long  number) {
     // Don't translate an empty string as it will return the PO meta data.
     if (singular.empty() || plural.empty())
-         return std::string();
-
-    va_list va;
-    va_start(va, number);
+        return std::string();
     std::string translation = ngettext(singular.c_str(), plural.c_str(), number);
-    translation = strprintf(translation.c_str(), number, va);
-    va_end(va);
+    translation = strprintf(translation.c_str(), number);
     return translation;
 }
 
+std::string NVTranslate(const std::string &singular, const std::string &plural, const unsigned long number, const char* str) {
+    // Don't translate an empty string as it will return the PO meta data.
+    if (singular.empty() || plural.empty())
+        return std::string();
+    std::string translation = ngettext(singular.c_str(), plural.c_str(), number);
+    std::cout << translation.c_str() << "\n";
+    translation = strprintf(translation.c_str(), number, str);
+    return translation;
+}
 
 // -----------------------------------------------------------------------------
 // SystemTimer Class
@@ -541,7 +546,7 @@ void SystemEngine::AddAutoTimer(SystemTimer *timer)
         return;
     }
 
-//     pair<set<SystemTimer*>::iterator, bool> return_value;
+//    pair<set<SystemTimer*>::iterator, bool> return_value;
     if(_auto_system_timers.insert(timer).second == false) {
         IF_PRINT_WARNING(SYSTEM_DEBUG) << "timer already existed in auto system timer container" << std::endl;
     }

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -119,6 +119,15 @@ std::string VTranslate(const std::string &text, float arg1);
 std::string VTranslate(const std::string &text, uint32_t arg1, uint32_t arg2);
 std::string VTranslate(const std::string &text, const std::string &arg1, const std::string &arg2);
 
+/** \brief Returns the translated string fprinted with the c-formatted number.
+***        Add as many printf variables as you like to the end.
+*** \param singular The singular form of the text to transform containing c-format number
+*** \param plural The plural form of the text to transform containing c-format number
+*** \param arg1 The number.
+*** \param ... Any number of further arguments to hand over to the formatting part.
+**/
+std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long number, ...);
+
 /** ****************************************************************************
 *** \brief Class of properties about locales
 *** ***************************************************************************/

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -120,13 +120,20 @@ std::string VTranslate(const std::string &text, uint32_t arg1, uint32_t arg2);
 std::string VTranslate(const std::string &text, const std::string &arg1, const std::string &arg2);
 
 /** \brief Returns the translated string fprinted with the c-formatted number.
-***        Add as many printf variables as you like to the end.
 *** \param singular The singular form of the text to transform containing c-format number
 *** \param plural The plural form of the text to transform containing c-format number
-*** \param arg1 The number.
-*** \param ... Any number of further arguments to hand over to the formatting part.
+*** \param number The number.
 **/
-std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long number, ...);
+std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long number);
+
+/** \brief Returns the translated string fprinted with the c-formatted number.
+***        Adds an additional printf string argument to the end.
+*** \param singular The singular form of the text to transform containing c-format number
+*** \param plural The plural form of the text to transform containing c-format number
+*** \param number The number.
+*** \param str An additional string argument for printf.
+**/
+std::string NVTranslate(const std::string &singular, const std::string &plural, unsigned long number, const char* str);
 
 /** ****************************************************************************
 *** \brief Class of properties about locales

--- a/src/modes/map/map_treasure.cpp
+++ b/src/modes/map/map_treasure.cpp
@@ -318,9 +318,19 @@ void TreasureSupervisor::_UpdateList()
             // If true, the drunes have been selected
             _selection_name.SetText(UTranslate("Drunes"));
             _selection_icon = GlobalManager->Media().GetDrunesIcon();
-            _detail_textbox.SetDisplayText(VTranslate("With the additional %u drunes found in this treasure added, "
-                                                      "the party now holds a total of %u drunes.",
-                                                      _treasure->_drunes, GlobalManager->GetDrunes()));
+
+                // Part 2 of "With the additional %u drune(s) found in this treasure added, ... "
+                const std::string temp_string =
+                    NVTranslate("the party now holds a total of %u drune.",
+                                "the party now holds a total of %u drunes.",
+                                GlobalManager->GetDrunes());
+
+                // %s will be replaced with "the party now holds a total of %u drune(s)."
+                _detail_textbox.SetDisplayText(
+                    NVTranslate("With the additional %u drune found in this treasure added, %s.",
+                                "With the additional %u drunes found in this treasure added, %s.",
+                                _treasure->_drunes,
+                                temp_string));
             _is_key_item = false;
         } else { // Otherwise, a GlobalObject is selected
             if(_treasure->_drunes != 0)

--- a/src/modes/map/map_treasure.cpp
+++ b/src/modes/map/map_treasure.cpp
@@ -330,7 +330,7 @@ void TreasureSupervisor::_UpdateList()
                     NVTranslate("With the additional %u drune found in this treasure added, %s.",
                                 "With the additional %u drunes found in this treasure added, %s.",
                                 _treasure->_drunes,
-                                temp_string));
+                                temp_string.c_str()));
             _is_key_item = false;
         } else { // Otherwise, a GlobalObject is selected
             if(_treasure->_drunes != 0)


### PR DESCRIPTION
This adds support for ngettext to C++ and fixes the extraction of comments in C++.

For calling ngettext, there are two new convenience functions NVTranslate that will automatically format the text as well. One of them will accept an additional char* variable.