### PR TITLE
Fixed comments and empty strings in translations

### DIFF
--- a/data/boot_menu/boot.lua
+++ b/data/boot_menu/boot.lua
@@ -48,8 +48,8 @@ function Initialize(boot_instance)
     satellite_shadow_image:SetDimensions(48.0, 32.0);
     flare_image = Script:CreateImage("data/boot_menu/ep1/flare.png");
 
-    -- /// Translators: The logo file path here can be overidden to an image of the logo made for your country language.
-    -- /// Leave the same value if you don't plan to change this image.
+    -- /// tr: The logo file path here can be overidden to an image of the logo made for your country language.
+    -- /// tr: Leave the same value if you don't plan to change this image.
     local logo_filepath = vt_system.Translate("data/boot_menu/valyria_logo.png");
     logo_image = Script:CreateImage(logo_filepath);
 

--- a/data/credits/end_credits.lua
+++ b/data/credits/end_credits.lua
@@ -25,8 +25,8 @@ function Initialize(map_instance)
 
     Script = Map:GetScriptSupervisor();
 
-    -- /// Translators: The logo file path here can be overidden to an image of the logo made for your country language.
-    -- /// Leave the same value if you don't plan to change this image.
+    -- /// tr: The logo file path here can be overidden to an image of the logo made for your country language.
+    -- /// tr: Leave the same value if you don't plan to change this image.
     local logo_filepath = vt_system.Translate("data/boot_menu/valyria_logo.png");
 
     credit_map = {

--- a/po/CMakeLists.txt
+++ b/po/CMakeLists.txt
@@ -64,11 +64,11 @@ MACRO(VALYRIATEAR_GETTEXT_UPDATE_PO _potFile _languages)
 
    ADD_CUSTOM_TARGET(
       update-pot
-      # Strings from C++
-      COMMAND xgettext -C --files-from=translatable-files --directory=. --output=${_potFile} -d valyriatear --keyword=_ --keyword=N_ --keyword=Translate --keyword=UTranslate --keyword=CTranslate --keyword=CUTranslate --keyword=VTranslate:1 --keyword=NVTranslate:1,2 --add-comments --from-code=UTF-8
-      # Strings from Lua
+      # Strings from C++ and Lua
+      COMMAND xgettext -C --files-from=translatable-files --directory=. --output=${_potFile} -d valyriatear --keyword=_ --keyword=N_ --keyword=Translate --keyword=UTranslate --keyword=CTranslate --keyword=CUTranslate --keyword=VTranslate:1 --keyword=NVTranslate:1,2 --add-comments=tr: --from-code=UTF-8
+      # Map names from Lua
       COMMAND bash create_map_names_translatable_strings.sh
-      COMMAND xgettext -C --directory=. -j --output=${_potFile} -d valyriatear --keyword=Translate --add-comments --from-code=UTF-8  map_names_tr.lua
+      COMMAND xgettext -C --directory=. -j --output=${_potFile} -d valyriatear --keyword=Translate --add-comments=tr: --from-code=UTF-8  map_names_tr.lua
 
       # The pot file is ready - We can remove the temp files
       COMMAND rm -f translatable-files

--- a/po/create_map_names_translatable_strings.sh
+++ b/po/create_map_names_translatable_strings.sh
@@ -1,14 +1,18 @@
 # Empties the map names translation files
-echo "" > map_names_tr.lua
+echo -n "" > map_names_tr.lua
 
 cat map_names_files |
 while read a; do
 
-    echo -n "Translate(" >> map_names_tr.lua
-    cat  $a | grep 'map_name' | cut -d'=' -f2 | sed s/\ \"/\"/ >> map_names_tr.lua
-    echo ")" >> map_names_tr.lua
-
-    echo -n "Translate(" >> map_names_tr.lua
-    cat  $a | grep 'map_subname' | cut -d'=' -f2 | sed s/\ \"/\"/ >> map_names_tr.lua
-    echo ")" >> map_names_tr.lua
+    # Get map name or map subname
+    MAP_NAME=""
+    MAP_NAME=$(cat  $a | grep 'map_name' | cut -d'=' -f2 | sed s/\ \"/\"/)
+    if [ "$MAP_NAME" = "\"\"" -o "$MAP_NAME" = "" ]; then
+        MAP_NAME=$(cat  $a | grep 'map_subname' | cut -d'=' -f2 | sed s/\ \"/\"/)
+    fi
+    # Add map name if it's not empty
+    if [[ "$MAP_NAME" != "\"\"" && "$MAP_NAME" != "" ]]; then
+        echo "/// tr: Map name" >> map_names_tr.lua
+        echo "Translate("$MAP_NAME")" >> map_names_tr.lua
+    fi
 done

--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -365,7 +365,7 @@ void GameOptionsMenuHandler::ReloadTranslatableMenus()
     // Reset the window title
     SDL_Window* sdl_window = VideoManager->GetWindowHandle();
     if (sdl_window) {
-        /// Translators: The window title only supports UTF-8 characters in SDL2.
+        /// tr: The window title only supports UTF-8 characters in SDL2.
         std::string AppFullName = vt_system::Translate("Valyria Tear");
         SDL_SetWindowTitle(sdl_window, AppFullName.c_str());
     }
@@ -691,7 +691,7 @@ void GameOptionsMenuHandler::_RefreshVideoOptions()
     // Update the Vsync mode
     std::string vsync_str;
     bool update_mode_enabled = true;
-    /// Translators: Do not translate the part before the '|'.
+    /// tr: Do not translate the part before the '|'.
     /// It is used for contextual translation support.
     switch(VideoManager->GetVSyncMode()) {
     default:
@@ -713,7 +713,7 @@ void GameOptionsMenuHandler::_RefreshVideoOptions()
     // The VSync method will auto limit the framerate.
     if (update_mode_enabled) {
         std::string update_mode_str;
-        /// Translators: Do not translate the part before the '|'.
+        /// tr: Do not translate the part before the '|'.
         /// It is used for contextual translation support.
         if (VideoManager->GetGameUpdateMode())
             update_mode_str = CTranslate("UpdateMode|Performance");

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -538,7 +538,7 @@ int main(int argc, char* argv[])
     VideoManager->ApplySettings();
 
     // Now the settings are loaded, let's set the windows translated title.
-    /// Translators: The window title only supports UTF-8 characters in SDL2.
+    /// tr: The window title only supports UTF-8 characters in SDL2.
     std::string app_fullname = vt_system::Translate("Valyria Tear");
     SDL_SetWindowTitle(sdl_window, app_fullname.c_str());
 

--- a/src/modes/battle/battle_command.cpp
+++ b/src/modes/battle/battle_command.cpp
@@ -1228,7 +1228,7 @@ std::string _TurnIntoSeconds(uint32_t milliseconds)
     uint32_t seconds = milliseconds / 1000;
     uint32_t dec = (milliseconds / 100) - (seconds * 10);
     std::string formatted_seconds = NumberToString(seconds) + "." + NumberToString(dec);
-    /// TRANSLATORS: this is about displaying a time: eg 4.2s
+    /// tr: this is about displaying a time: eg 4.2s
     formatted_seconds = VTranslate("%ss", formatted_seconds);
     return formatted_seconds;
 }

--- a/src/modes/battle/battle_finish.cpp
+++ b/src/modes/battle/battle_finish.cpp
@@ -785,7 +785,7 @@ void FinishVictoryAssistant::_UpdateGrowth()
                 _growth_list[i].AddOptionElementImage(line, media.GetStatusIcon(vt_global::GLOBAL_STATUS_EVADE,
                                                                                 vt_global::GLOBAL_INTENSITY_NEUTRAL));
                 _growth_list[i].AddOptionElementPosition(line, 32);
-                /// TRANSLATORS: This is the evade growth score. E.g.: +1%, +1.5%
+                /// tr: This is the evade growth score. E.g.: +1%, +1.5%
                 _growth_list[i].AddOptionElementText(line, MakeUnicodeString(VTranslate("+%f%%", NumberToString(_character_growths[i].evade))));
                 line = line + 2;
             }

--- a/src/modes/map/map_treasure_supervisor.cpp
+++ b/src/modes/map/map_treasure_supervisor.cpp
@@ -295,13 +295,13 @@ void TreasureSupervisor::_UpdateList()
             _selection_icon = GlobalManager->Media().GetDrunesIcon();
 
             const std::string temp_string =
-                // Part 2 of "With the additional %u drune(s) found in this treasure added, ... "
+                /// tr: Part 2 of "With the additional %u drune(s) found in this treasure added, ... "
                 NVTranslate("the party now holds a total of %u drune.", // singular
                             "the party now holds a total of %u drunes.", // plural
                             GlobalManager->GetDrunes());
 
             _detail_textbox.SetDisplayText(
-                // %s will be replaced with "the party now holds a total of %u drune(s)."
+                /// tr: %s will be replaced with "the party now holds a total of %u drune(s)."
                 NVTranslate("With the additional %u drune found in this treasure added, %s.", // sinlgular
                             "With the additional %u drunes found in this treasure added, %s.", // plural
                             _treasure->_drunes,

--- a/src/modes/menu/menu_character_window.cpp
+++ b/src/modes/menu/menu_character_window.cpp
@@ -66,11 +66,13 @@ void CharacterWindow::SetCharacter(vt_global::GlobalCharacter* character)
     _character_name.SetText(character->GetName(), TextStyle("title22"));
 
     // And the rest of the data
+    /// tr: level
     ustring char_data = UTranslate("Lv: ") + MakeUnicodeString(NumberToString(character->GetExperienceLevel()) + "\n");
     char_data += MakeUnicodeString("      " + NumberToString(character->GetHitPoints()) +
                  " / " + NumberToString(character->GetMaxHitPoints()) + "\n");
     char_data += MakeUnicodeString("      " + NumberToString(character->GetSkillPoints()) +
                  " / " + NumberToString(character->GetMaxSkillPoints()) + "\n");
+    /// tr: experience points
     char_data += UTranslate("XP to Next: ") + MakeUnicodeString(NumberToString(character->GetExperienceForNextLevel()));
 
     _character_data.SetText(char_data, TextStyle("text20"));

--- a/src/modes/save/save_mode.cpp
+++ b/src/modes/save/save_mode.cpp
@@ -775,9 +775,12 @@ void SmallCharacterWindow::SetCharacter(GlobalCharacter* character)
     _character_name.SetText(_character->GetName(), TextStyle("title22"));
 
     // And the rest of the data
+    /// tr: level
     ustring char_data = UTranslate("Lv: ") + MakeUnicodeString(NumberToString(_character->GetExperienceLevel()) + "\n");
+    /// tr: hit points
     char_data += UTranslate("HP: ") + MakeUnicodeString(NumberToString(_character->GetHitPoints()) +
                                " / " + NumberToString(_character->GetMaxHitPoints()) + "\n");
+    /// tr: skill points
     char_data += UTranslate("SP: ") + MakeUnicodeString(NumberToString(_character->GetSkillPoints()) +
                                " / " + NumberToString(_character->GetMaxSkillPoints()));
 


### PR DESCRIPTION
- Changed translation comment marker to tr: and added a few more
comments.
- Removed empty map names from the string collection bash script