### PR TITLE
Some small i18n fixes

### DIFF
--- a/src/engine/indicator_supervisor.cpp
+++ b/src/engine/indicator_supervisor.cpp
@@ -173,7 +173,9 @@ IndicatorText::IndicatorText(float x_position, float y_position,
 void IndicatorText::Draw()
 {
     VideoManager->SetDrawFlags(VIDEO_X_RIGHT, VIDEO_Y_BOTTOM, VIDEO_BLEND, 0);
-    VideoManager->Move(_x_origin_position + _x_relative_position, _y_origin_position - _y_relative_position);
+    VideoManager->Move(
+        _x_origin_position + _x_relative_position + _text_image.GetWidth() / 2,
+        _y_origin_position - _y_relative_position);
 
     _text_image.Draw(_alpha_color);
 }

--- a/src/modes/battle/battle_finish.cpp
+++ b/src/modes/battle/battle_finish.cpp
@@ -534,7 +534,14 @@ void FinishVictoryAssistant::_SetHeaderText()
     }
 
     const uint32_t no_of_options = _object_list.GetNumberOptions();
-    _object_header_text.SetDisplayText(no_of_options == 0 ? UTranslate("No Items Found") : no_of_options == 1 ? UTranslate("Item Found") : UTranslate("Items Found"));
+    _object_header_text.SetDisplayText(no_of_options == 0 ?
+        // tr: Header in battle result screen: 0 items found
+            UTranslate("No Items Found") :
+                no_of_options == 1 ?
+                    // tr: Header in battle result screen: 1 item found
+                    UTranslate("Item Found") :
+                    // tr: Header in battle result screen: more than 1 item found
+                    UTranslate("Items Found"));
 }
 
 void FinishVictoryAssistant::_CreateCharacterGUIObjects()

--- a/src/modes/battle/battle_finish.cpp
+++ b/src/modes/battle/battle_finish.cpp
@@ -532,6 +532,9 @@ void FinishVictoryAssistant::_SetHeaderText()
     } else {
         IF_PRINT_WARNING(BATTLE_DEBUG) << "invalid finish state: " << _state << std::endl;
     }
+
+    const uint32_t no_of_options = _object_list.GetNumberOptions();
+    _object_header_text.SetDisplayText(no_of_options == 0 ? UTranslate("No Items Found") : no_of_options == 1 ? UTranslate("Item Found") : UTranslate("Items Found"));
 }
 
 void FinishVictoryAssistant::_CreateCharacterGUIObjects()

--- a/src/modes/save/save_mode.cpp
+++ b/src/modes/save/save_mode.cpp
@@ -498,10 +498,12 @@ bool SaveMode::_LoadGame(const std::string& filename)
 
 void SaveMode::_ClearSaveData(bool selected_file_exists)
 {
-    if (selected_file_exists)
+    if (selected_file_exists) {
         _map_name_textbox.SetDisplayText(UTranslate("Invalid data!"));
-    else
-        _map_name_textbox.SetDisplayText(UTranslate("No data"));
+    } else {
+        // tr: A slot for saving the same
+        _map_name_textbox.SetDisplayText(UTranslate("This slot is unused"));
+    }
     _time_textbox.ClearText();
     _drunes_textbox.ClearText();
     _location_image.Clear();

--- a/src/modes/shop/shop.cpp
+++ b/src/modes/shop/shop.cpp
@@ -170,8 +170,8 @@ ShopObjectViewer::ShopObjectViewer() :
     // Position and dimensions for _count_text are set by _SetCountText()
     _count_text.SetTextStyle(TextStyle("text28"));
     _count_text.SetDisplayMode(VIDEO_TEXT_INSTANT);
-    _count_text.SetAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
-    _count_text.SetTextAlignment(VIDEO_X_LEFT, VIDEO_Y_TOP);
+    _count_text.SetAlignment(VIDEO_X_RIGHT, VIDEO_Y_TOP);
+    _count_text.SetTextAlignment(VIDEO_X_RIGHT, VIDEO_Y_TOP);
     _count_text.SetPosition(550.0f, 22.0f);
     _count_text.SetDimensions(325.0f, 10.0f);
 


### PR DESCRIPTION
- Battle Indicator: Start text indicator centered, so long text won't go
off the left edge of the screen too fast
- Battle Finish: Adjust "Items Found" header according to number of
items
- Save Mode: Replaced "No data" with "This slot is unused" in order to
be less geeky