### PR TITLE
Make it easier to confirm an action

### DIFF
--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -185,6 +185,13 @@ void GameOptionsMenuHandler::ShowFirstRunLanguageSelection()
     _first_run = true;
     _options_window.Show();
     _active_menu = &_language_options_menu;
+
+	_explanation_window.SetText(
+				MakeUnicodeString(
+					VTranslate("Use the %s and %s keys to select your language and then press %s.",
+							   Translate(InputManager->GetUpKeyName()),
+							   Translate(InputManager->GetDownKeyName()),
+							   Translate(InputManager->GetConfirmKeyName()))));
 }
 
 void GameOptionsMenuHandler::Update()

--- a/src/engine/input.cpp
+++ b/src/engine/input.cpp
@@ -628,7 +628,8 @@ void InputEngine::_JoystickEventHandler(SDL_Event &js_event)
 void InputEngine::_SetNewKey(SDL_Keycode &old_key, SDL_Keycode new_key)
 {
     // Don't permit system keys (Quit and help)
-    if(new_key == SDLK_ESCAPE || new_key == SDLK_F1)
+    if(new_key == SDLK_ESCAPE || new_key == SDLK_F1 ||
+	   new_key == SDLK_RETURN || new_key == SDLK_KP_ENTER)
         return;
 
     if(_key.up == new_key) {  // up key used already

--- a/src/engine/input.cpp
+++ b/src/engine/input.cpp
@@ -370,7 +370,7 @@ void InputEngine::_KeyEventHandler(SDL_KeyboardEvent &key_event)
             _right_state = true;
             _right_press = true;
             return;
-        } else if(key_event.keysym.sym == _key.confirm) {
+        } else if(key_event.keysym.sym == _key.confirm || key_event.keysym.sym == SDLK_RETURN || key_event.keysym.sym == SDLK_KP_ENTER) {
             _confirm_state = true;
             _confirm_press = true;
             return;
@@ -418,7 +418,7 @@ void InputEngine::_KeyEventHandler(SDL_KeyboardEvent &key_event)
             _right_state = false;
             _right_release = true;
             return;
-        } else if(key_event.keysym.sym == _key.confirm) {
+        } else if(key_event.keysym.sym == _key.confirm || key_event.keysym.sym == SDLK_RETURN || key_event.keysym.sym == SDLK_KP_ENTER) {
             _confirm_state = false;
             _confirm_release = true;
             return;

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -52,7 +52,7 @@ class KeyState
 public:
     /** \name Generic key code names (layout-dependant, not scancodes)
     *** \brief Each member holds the actual keyboard key that corresponds to the named key event.
-    *** \note that SDLK_ESCAPE and SDLK_F1 are reserved for Quit, and Help.
+    *** \note that SDLK_ESCAPE is reserved for Quit, SDLK_F1 for Help, and SDLK_RETURN and SDLK_KP_ENTER for Confirm.
     **/
     //@{
     SDL_Keycode up;

--- a/src/engine/system.cpp
+++ b/src/engine/system.cpp
@@ -125,6 +125,18 @@ template<typename T> std::string _VTranslate(const std::string& text, const T& a
     return translation;
 }
 
+template<typename T> std::string _VTranslate(const std::string& text, const T& arg1, const T& arg2, const T& arg3)
+{
+    // Don't translate an empty string as it will return the PO meta data.
+	if (text.empty()) {
+        return std::string();
+	}
+
+    std::string translation = gettext(text.c_str());
+    translation = strprintf(translation.c_str(), arg1, arg2, arg3);
+    return translation;
+}
+
 std::string VTranslate(const std::string& text, int32_t arg1)
 { return _VTranslate(text, arg1); }
 std::string VTranslate(const std::string& text, uint32_t arg1)
@@ -137,6 +149,8 @@ std::string VTranslate(const std::string& text, uint32_t arg1, uint32_t arg2)
 { return _VTranslate(text, arg1, arg2); }
 std::string VTranslate(const std::string& text, const std::string& arg1, const std::string& arg2)
 { return _VTranslate(text, arg1.c_str(), arg2.c_str()); }
+std::string VTranslate(const std::string& text, const std::string& arg1, const std::string& arg2, const std::string& arg3)
+{ return _VTranslate(text, arg1.c_str(), arg2.c_str(), arg3.c_str()); }
 
 std::string NVTranslate(const std::string& singular,
                         const std::string& plural,

--- a/src/engine/system.h
+++ b/src/engine/system.h
@@ -121,6 +121,7 @@ std::string VTranslate(const std::string &text, float arg1);
 // Example with 2 args, used in the treasure supervisor
 std::string VTranslate(const std::string &text, uint32_t arg1, uint32_t arg2);
 std::string VTranslate(const std::string &text, const std::string &arg1, const std::string &arg2);
+std::string VTranslate(const std::string &text, const std::string &arg1, const std::string &arg2, const std::string &arg3);
 
 // TODO: Use Lua Array with luabind so pass a random amount of parameters.
 /** \brief Returns the translated string fprinted with the c-formatted number.


### PR DESCRIPTION
- Add Return and Keypad Enter as hard-coded alternatives to the
  Confirm key to make basic menu navigation easier for new players.

- On first run, show help text for keyboard navigation in the language
  menu, because the navigation help window hasn't been shown yet.