### PR TITLE
Fix corrupted key selection

### DIFF
--- a/src/common/options_handler.cpp
+++ b/src/common/options_handler.cpp
@@ -232,7 +232,7 @@ void GameOptionsMenuHandler::Update()
     // Check for waiting keypresses or joystick button presses
     if(_joy_setting_function != nullptr) {
         if(InputManager->AnyJoystickKeyPress()) {
-            (this->*_joy_setting_function)(InputManager->GetMostRecentEvent().jbutton.button);
+            (this->*_joy_setting_function)(InputManager->GetMostRecentJoystickEvent().jbutton.button);
             _joy_setting_function = nullptr;
             _has_modified_settings = true;
             _RefreshJoySettings();
@@ -263,7 +263,7 @@ void GameOptionsMenuHandler::Update()
 
     if(_key_setting_function != nullptr) {
         if(InputManager->AnyKeyboardKeyPress()) {
-            (this->*_key_setting_function)(InputManager->GetMostRecentEvent().key.keysym.sym);
+            (this->*_key_setting_function)(InputManager->GetMostRecentKeyEvent().key.keysym.sym);
             _key_setting_function = nullptr;
             _has_modified_settings = true;
             _RefreshKeySettings();

--- a/src/engine/input.cpp
+++ b/src/engine/input.cpp
@@ -262,13 +262,15 @@ void InputEngine::EventHandler()
 
     // Loops until there are no remaining events to process
     while(SDL_PollEvent(&event)) {
-        _event = event;
         if(event.type == SDL_QUIT) {
+            _key_event = event;
             _quit_press = true;
             break;
         } else if(event.type == SDL_KEYUP || event.type == SDL_KEYDOWN) {
+            _key_event = event;
             _KeyEventHandler(event.key);
         } else {
+            _joystick_event = event;
             _JoystickEventHandler(event);
         }
     }

--- a/src/engine/input.h
+++ b/src/engine/input.h
@@ -251,9 +251,12 @@ private:
     bool _hat_right_state;
     //@}
 
-    /** \brief Most recent SDL event
+    /** \brief Most recent SDL joystick event
      **/
-    SDL_Event _event;
+    SDL_Event _joystick_event;
+	/** \brief Most recent SDL key event
+     **/
+	SDL_Event _key_event;
 
     /** \brief Processes all keyboard input events
     *** \param key_event The event to process
@@ -729,9 +732,13 @@ public:
     }
     //@}
 
-    //! \brief Returns the most recent event retrieved from SDL
-    const SDL_Event &GetMostRecentEvent() const {
-        return _event;
+    //! \brief Returns the most recent joystick event retrieved from SDL
+    const SDL_Event &GetMostRecentJoystickEvent() const {
+        return _joystick_event;
+    }
+	//! \brief Returns the most recent key event retrieved from SDL
+	const SDL_Event &GetMostRecentKeyEvent() const {
+        return _key_event;
     }
 }; // class InputEngine : public vt_utils::Singleton<InputEngine>
 

--- a/src/modes/boot/boot.cpp
+++ b/src/modes/boot/boot.cpp
@@ -279,7 +279,7 @@ void BootMode::Update()
     if(InputManager->QuitPress()) {
         // Don't quit the game when using the joystick,
         // as it is confusing for the user.
-        SDL_Event ev = InputManager->GetMostRecentEvent();
+        SDL_Event ev = InputManager->GetMostRecentKeyEvent();
         if (ev.type == SDL_KEYDOWN)
             SystemManager->ExitGame();
     }


### PR DESCRIPTION
Fix corrupted key selection by separating joystick events from key
events

Closes https://github.com/ValyriaTear/ValyriaTear/issues/618