### PR TITLE
Fix Version tag in desktop file

### DIFF
--- a/valyriatear.desktop
+++ b/valyriatear.desktop
@@ -1,10 +1,12 @@
 [Desktop Entry]
-Version=1.1.0
+Version=1.0
 Name=Valyria Tear
 Name[gl]=A bágoa de Valïria
 Comment=A 2D J-RPG
-Comment[fr]=Un J-RPG 2D
+Comment[de]=2D-Rollenspiel
+Comment[fr]=Un J-RPG en 2D
 Comment[gl]=Xogo de rol en dúas dimensións
+Comment[it]=Giochi di ruolo in 2D
 Exec=valyriatear
 StartupNotify=false
 Terminal=false


### PR DESCRIPTION
The Version is for the version of the desktop file specification,
not the application.

1.1.0 is not a valid specification version.

Fixes:
```
$ desktop-file-validate valyriatear.desktop 
valyriatear.desktop: error: value "1.1.0" for key "Version" in group "Desktop Entry" is not a known version
```

Also added Comment translations I was carrying around in my Mageia package for some reason.