### PR TITLE
Fix build on big-endian platforms

### DIFF
--- a/src/engine/audio/audio_input.cpp
+++ b/src/engine/audio/audio_input.cpp
@@ -27,6 +27,7 @@
 #include "utils/utils_common.h"
 
 #include <cstring>
+#include <SDL_endian.h>
 
 namespace vt_audio
 {


### PR DESCRIPTION
SDL_Swap32() and SDL_Swap16() are defined in SDL_endian.h.