### PR TITLE
ShopData: Add stdint.h include to use uint32_t

### DIFF
--- a/src/common/global/shop/shop_data.h
+++ b/src/common/global/shop/shop_data.h
@@ -12,6 +12,7 @@
 #define __SHOP_DATA_HEADER__
 
 #include <map>
+#include <stdint.h>
 
 namespace vt_global {
 


### PR DESCRIPTION
Fixes build issue with GCC 10 and matching libstdc++:
```
In file included from /home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data_handler.h:14,
                 from /home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data_handler.cpp:11:
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:14: error: 'uint32_t' was not declared in this scope
   28 |     std::map<uint32_t, uint32_t> _available_buy;
      |              ^~~~~~~~
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:24: error: 'uint32_t' was not declared in this scope
   28 |     std::map<uint32_t, uint32_t> _available_buy;
      |                        ^~~~~~~~
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:32: error: template argument 1 is invalid
   28 |     std::map<uint32_t, uint32_t> _available_buy;
      |                                ^
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:32: error: template argument 2 is invalid
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:32: error: template argument 3 is invalid
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:28:32: error: template argument 4 is invalid
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:14: error: 'uint32_t' was not declared in this scope
   29 |     std::map<uint32_t, uint32_t> _available_trade;
      |              ^~~~~~~~
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:24: error: 'uint32_t' was not declared in this scope
   29 |     std::map<uint32_t, uint32_t> _available_trade;
      |                        ^~~~~~~~
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:32: error: template argument 1 is invalid
   29 |     std::map<uint32_t, uint32_t> _available_trade;
      |                                ^
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:32: error: template argument 2 is invalid
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:32: error: template argument 3 is invalid
/home/iurt/rpmbuild/BUILD/ValyriaTear/src/common/global/shop/shop_data.h:29:32: error: template argument 4 is invalid
```